### PR TITLE
Update dependency paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
   - $TESTCMD --check-bounds=yes -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Mimi"); Pkg.test("Mimi"; coverage=true)'
+  - julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url = "https://github.com/mimiframework/MimiRegistry.git"))'
+  - julia -e 'using Pkg; Pkg.add("MimiFUND")'
+  - julia -e 'using Pkg; Pkg.add("MimiRICE2010")'
   - julia --check-bounds=yes -e 'include("test/test_dependencies.jl"); run_dependency_tests()'
 after_success:
   - julia -e 'using Pkg; cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pkg> add MimiRICE2010
 * [MimiFUND.jl](https://github.com/fund-model/MimiFUND.jl) (currently in beta)
 * [MimiDICE2010.jl](https://github.com/anthofflab/MimiDICE2010.jl) (currently in closed beta)
 * [MimiDICE2013.jl](https://github.com/anthofflab/MimiDICE2013.jl) (currently in closed beta)
-* [MimiRICE2010.jl](https://github.com/anthofflab/MimiRICE2010.jl))
+* [MimiRICE2010.jl](https://github.com/anthofflab/MimiRICE2010.jl)
 * [Mimi-SNEASY.jl](https://github.com/anthofflab/mimi-sneasy.jl) (currently in closed beta)
 * [Mimi-FAIR.jl](https://github.com/anthofflab/mimi-fair.jl) (currently in closed beta)
 * [MimiPAGE2009.jl](https://github.com/anthofflab/MimiPAGE2009.jl) (currently in closed beta)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,7 @@ pkg> add MimiRICE2010
 * [MimiFUND.jl](https://github.com/fund-model/MimiFUND.jl) (currently in beta)
 * [MimiDICE2010.jl](https://github.com/anthofflab/MimiDICE2010.jl) (currently in closed beta)
 * [MimiDICE2013.jl](https://github.com/anthofflab/MimiDICE2013.jl) (currently in closed beta)
-* [MimiRICE2010.jl](https://github.com/anthofflab/MimiRICE2010.jl))
+* [MimiRICE2010.jl](https://github.com/anthofflab/MimiRICE2010.jl)
 * [Mimi-SNEASY.jl](https://github.com/anthofflab/mimi-sneasy.jl) (currently in closed beta)
 * [Mimi-FAIR.jl](https://github.com/anthofflab/mimi-fair.jl) (currently in closed beta)
 * [MimiPAGE2009.jl](https://github.com/anthofflab/MimiPAGE2009.jl) (currently in closed beta)

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -16,10 +16,9 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-    "https://github.com/fund-model/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993.zip",
-    "https://github.com/anthofflab/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
+    "https://github.com/fund-model/MimiFUND.jl/archive/4aa7146a735c547c9d4d0c63b9ecd64dbc4ed3e9.zip",
+    "https://github.com/anthofflab/MimiRICE2010.jl/archive/dc359f9350b2cfde51574e29070b9b8b162de1ec.zip"
 ]
-
 function run_dependency_tests(dependencies=dependencies)
     #list of failed tests to build as you go
     errors = []


### PR DESCRIPTION
This PR updates the dependency paths and adds the `MimiRegistry`, and then `MimiFUND` and `MimiRICE2010` to the Travis testing scripts so we can run the dependencies.  The tests will start passing once the `MimiFUND` and `MimiRICE2010` cleaned up packages are properly registered with the registry so that the clean versions are downloaded with `Pkg.add("MimiFUND")` and `Pkg.add("MimiRICE2010")`