### PR TITLE
Make generate_trials filename kwarg default to nothing

### DIFF
--- a/docs/src/internals/montecarlo.md
+++ b/docs/src/internals/montecarlo.md
@@ -72,7 +72,7 @@ Latin Hypercube sampling divides the distribution into equally-spaced quantiles,
 The `generate_trials!` function is used to pre-generate data using the given `samplesize` and save all random variable values in the file `filename`. Its calling signature is:
 
 ```julia
-  generate_trials!(sim::Simulation, samplesize::Int; filename::String="")
+  generate_trials!(sim::Simulation, samplesize::Int; filename::Union{String, Nothing}=nothing)
 ```
 
 If the `sim` parameter has multiple scenarios and the `scenario_loop` placement is set to `OUTER`, this function must be called if the user wants to ensure the same trial data be used in each scenario. If this function is not called, new trial data will be generated for each scenario. 

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -140,20 +140,19 @@ function get_trial(sim::Simulation, trialnum::Int)
 end
 
 """
-    generate_trials!(sim::Simulation{T}, samples::Int; filename::String="")
+    generate_trials!(sim::Simulation{T}, samples::Int; filename::Union{String, Nothing}=nothing)
 
 Generate trials for the given Simulation instance using the defined `samplesize.
 Call this before running the sim to pre-generate data to be used by all scenarios. 
 Also saves inputs if a filename is given.
 """
 function generate_trials!(sim::Simulation{T}, samplesize::Int;
-                          filename::String="") where T <: AbstractSimulationData
-
+                        filename::Union{String, Nothing}=nothing) where T <: AbstractSimulationData
     sample!(sim, samplesize)
 
     # TBD: If user asks for trial data to be saved, generate it up-front, or 
     # open a file that can be written to for each trialnum/scenario set?
-    if filename != ""
+    if filename != nothing
         save_trial_inputs(sim, filename)
     end
 end


### PR DESCRIPTION
Change the `generate_trials` keyword argument `filename` default to `nothing` instead of `""`.  Addresses Issue #444.