### PR TITLE
Add a various method for Empirical Distribution

### DIFF
--- a/src/mcs/EmpiricalDistribution.jl
+++ b/src/mcs/EmpiricalDistribution.jl
@@ -56,6 +56,10 @@ function Base.length(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {N
     return length(d.values)
 end
 
+function Base.iterate(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {N}
+    return iterate(d.values)
+end
+
 function Statistics.quantile(d::EmpiricalDistribution, args...)
     indices = quantile.(d.dist, args...)
     return d.values[indices]

--- a/src/mcs/EmpiricalDistribution.jl
+++ b/src/mcs/EmpiricalDistribution.jl
@@ -56,6 +56,10 @@ function Base.length(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {N
     return length(d.values)
 end
 
+function Base.collect(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {N}
+    return collect(d.values)
+end
+
 function Base.iterate(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {N}
     return iterate(d.values)
 end

--- a/src/mcs/EmpiricalDistribution.jl
+++ b/src/mcs/EmpiricalDistribution.jl
@@ -52,6 +52,10 @@ function Statistics.var(d::EmpiricalDistribution)
     return var(d.values, d.weights, corrected=true)
 end
 
+function Base.length(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {N}
+    return length(d.values)
+end
+
 function Statistics.quantile(d::EmpiricalDistribution, args...)
     indices = quantile.(d.dist, args...)
     return d.values[indices]
@@ -66,3 +70,4 @@ function Random.rand!(d::EmpiricalDistribution, args::Vararg{Integer,N}) where {
     indices = rand!(d.dist, args...)
     return d.values[indices]
 end
+


### PR DESCRIPTION
@rjplevin these methods were added as I was trying to get `quantile.` to work, a can I may kick down the road but these methods are probably still worth adding.  Let me know if you think the three of them make sense.