### PR TITLE
Simulation update funcs

### DIFF
--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -38,7 +38,8 @@ end
 
 Return the name of `def`.  Possible `NamedDef`s include `DatumDef`, and `ComponentDef`.
 """
-name(def::NamedDef) = def.name
+name(def::NamedDef) = def.name          # old definition; should deprecate this...
+Base.nameof(def::NamedDef) = def.name   # 'nameof' is the more julian name
 
 number_type(md::ModelDef) = md.number_type
 

--- a/src/mcs/lhs.jl
+++ b/src/mcs/lhs.jl
@@ -163,18 +163,21 @@ function lhs(rvlist::Vector{RandomVariable}, trials::Int;
     return asDataFrame ? DataFrame(samples, map(rv->rv.name, rvlist)) : samples
 end
 
+function lhs(sim::LatinHypercubeSimulation; 
+             corrmatrix::Union{Matrix{Float64},Nothing}=nothing,
+             asDataFrame::Bool=true)
+    rvlist = collect(values(sim.rvdict))
+    lhs(rvlist, sim.trials, corrmatrix=corrmatrix, asDataFrame=asDataFrame)
+end
+
 function lhs!(sim::LatinHypercubeSimulation; corrmatrix::Union{Matrix{Float64},Nothing}=nothing)
     # TBD: verify that any correlated values are actual distributions, not stored vectors?
 
-    trials = sim.trials
     rvdict = sim.rvdict
-    num_rvs = length(rvdict)
-    rvlist = collect(values(sim.rvdict))
 
-    samples = lhs(rvlist, sim.trials, corrmatrix=corrmatrix, asDataFrame=false)
+    samples = lhs(sim, corrmatrix=corrmatrix, asDataFrame=false)
 
-    for (i, rv) in enumerate(rvlist)
-        dist = rv.dist
+    for (i, rv) in enumerate(values(rvdict))
         name = rv.name
         values = samples[:, i]
         rvdict[name] = RandomVariable(name, SampleStore(values))

--- a/src/mcs/lhs.jl
+++ b/src/mcs/lhs.jl
@@ -169,7 +169,7 @@ function lhs!(sim::LatinHypercubeSimulation; corrmatrix::Union{Matrix{Float64},N
     trials = sim.trials
     rvdict = sim.rvdict
     num_rvs = length(rvdict)
-    rvlist = sim.dist_rvs
+    rvlist = values(sim.rvdict)
 
     samples = lhs(rvlist, sim.trials, corrmatrix=corrmatrix, asDataFrame=false)
 

--- a/src/mcs/lhs.jl
+++ b/src/mcs/lhs.jl
@@ -169,7 +169,7 @@ function lhs!(sim::LatinHypercubeSimulation; corrmatrix::Union{Matrix{Float64},N
     trials = sim.trials
     rvdict = sim.rvdict
     num_rvs = length(rvdict)
-    rvlist = values(sim.rvdict)
+    rvlist = collect(values(sim.rvdict))
 
     samples = lhs(rvlist, sim.trials, corrmatrix=corrmatrix, asDataFrame=false)
 

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -127,7 +127,6 @@ mutable struct Simulation{T}
     rvdict::OrderedDict{Symbol, RandomVariable}
     translist::Vector{TransformSpec}
     savelist::Vector{Tuple{Symbol, Symbol}}
-    dist_rvs::Vector{RandomVariable}
     nt_type::Any                    # a generated NamedTuple type to hold data for a single trial
     models::Vector{Model}
     results::Vector{Dict{Tuple, DataFrame}}
@@ -144,7 +143,6 @@ mutable struct Simulation{T}
         self.rvdict = OrderedDict([rv.name => rv for rv in rvlist])
         self.translist = translist
         self.savelist = savelist
-        self.dist_rvs = [rv for rv in rvlist]
 
         names = (keys(self.rvdict)...,)
         types = [eltype(fld) for fld in values(self.rvdict)]

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -175,8 +175,11 @@ function Random.rand!(sim::Simulation{T}) where T <: AbstractSimulationData
     trials = sim.trials
 
     for rv in values(sim.rvdict)
-        values = rand(rv.dist, trials)
-        rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values))
+        # use underlying distribution, if known
+        orig_dist = (rv.dist isa SampleStore ? rv.dist.dist : rv.dist)
+        dist = (orig_dist === nothing ? rv.dist : orig_dist)
+        values = rand(dist, trials)
+        rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values, orig_dist))
     end
 end
 

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -174,7 +174,7 @@ function Random.rand!(sim::Simulation{T}) where T <: AbstractSimulationData
     rvdict = sim.rvdict
     trials = sim.trials
 
-    for rv in sim.dist_rvs
+    for rv in values(sim.rvdict)
         values = rand(rv.dist, trials)
         rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values))
     end

--- a/src/mcs/sobol.jl
+++ b/src/mcs/sobol.jl
@@ -15,34 +15,43 @@ end
 
 const SobolSimulation = Simulation{SobolData}
 
+function _compute_N(sim::SobolSimulation)
+    num_rvs = length(sim.rvdict)
+    factor = (sim.data.calc_second_order ? 2 : 1)
+    N = sim.trials / (factor * num_rvs + 2)
+    return N
+end
+
+function _compute_trials(sim::SobolSimulation, N::Int)
+    num_rvs = length(sim.rvdict)
+    factor = (sim.data.calc_second_order ? 2 : 1)
+    sim.trials = N * (factor * num_rvs + 2)
+end
+
+# Use original distribution when resampling from SampleStore
+_get_dist(rv::RandomVariable) = (rv.dist isa SampleStore ? rv.dist.dist : rv.dist)
+
 function sample!(sim::SobolSimulation, samplesize::Int)
-
     rvdict = sim.rvdict
-    rvlist = values(rvdict)
-    num_rvs = length(rvlist)
-
-    if sim.data.calc_second_order
-        sim.trials = samplesize * (2 * num_rvs + 2)
-    else
-        sim.trials = samplesize * (num_rvs + 2)
-    end
+    sim.trials = _compute_trials(sim, samplesize)
 
     # get the samples to plug in to trials
     payload = create_GSA_payload(sim)
     samples = GlobalSensitivityAnalysis.sample(payload)
 
-    for (i, rv) in enumerate(rvlist)
-        dist = rv.dist
+    for (i, rv) in enumerate(values(rvdict))
+        # use underlying distribution, if known
+        orig_dist = _get_dist(rv)
+
         name = rv.name
         values = samples[:, i]
-        rvdict[name] = RandomVariable(name, SampleStore(values))
+        rvdict[name] = RandomVariable(name, SampleStore(values, orig_dist))
     end
 end
 
 function analyze(sim::SobolSimulation, model_output::AbstractArray{<:Number, N1}; N::Union{Nothing, Int}=nothing) where N1
-    if N != nothing
-        sim.data.calc_second_order ? factor = 2 * length(sim.rvdict) : factor = length(sim.rvdict)
-        sim.trials = N * (factor + 2)
+    if N !== nothing
+        sim.trials = _compute_trials(sim, N)
     end
 
     if sim.trials == 0
@@ -54,25 +63,11 @@ function analyze(sim::SobolSimulation, model_output::AbstractArray{<:Number, N1}
 end
 
 function create_GSA_payload(sim::SobolSimulation)
-
-    rvlist = collect(values(sim.rvdict))
-
-    # add all distinct rvs to the rv_info dictionary to be passed to GSA's 
-    # SobolData payload
-    rv_info = OrderedDict{Symbol, Any}(rvlist[1].name => rvlist[1].dist)
-    for rv in rvlist[2:end] 
-        rv_info[rv.name] = rv.dist
-    end
+    rv_info = OrderedDict{Symbol, Any}([name => _get_dist(rv) for (name, rv) in sim.rvdict])
 
     # back out N
-    num_rvs = length(sim.rvdict)
-    if sim.data.calc_second_order
-        samples = sim.trials / (2 * num_rvs + 2)
-    else
-        samples = sim.trials / (num_rvs + 2)
-    end
+    N = _compute_N(sim)
 
     # create payload
-    return GlobalSensitivityAnalysis.SobolData(params = rv_info, calc_second_order = sim.data.calc_second_order, N = samples)
-    
+    return GlobalSensitivityAnalysis.SobolData(params = rv_info, calc_second_order = sim.data.calc_second_order, N = N)
 end

--- a/src/mcs/sobol.jl
+++ b/src/mcs/sobol.jl
@@ -55,7 +55,7 @@ end
 
 function create_GSA_payload(sim::SobolSimulation)
 
-    rvlist = values(sim.rvdict)
+    rvlist = collect(values(sim.rvdict))
 
     # add all distinct rvs to the rv_info dictionary to be passed to GSA's 
     # SobolData payload

--- a/src/mcs/sobol.jl
+++ b/src/mcs/sobol.jl
@@ -18,8 +18,8 @@ const SobolSimulation = Simulation{SobolData}
 function sample!(sim::SobolSimulation, samplesize::Int)
 
     rvdict = sim.rvdict
-    rvlist = sim.dist_rvs
-    num_rvs = length(rvdict)
+    rvlist = values(rvdict)
+    num_rvs = length(rvlist)
 
     if sim.data.calc_second_order
         sim.trials = samplesize * (2 * num_rvs + 2)
@@ -55,7 +55,7 @@ end
 
 function create_GSA_payload(sim::SobolSimulation)
 
-    rvlist = sim.dist_rvs
+    rvlist = values(sim.rvdict)
 
     # add all distinct rvs to the rv_info dictionary to be passed to GSA's 
     # SobolData payload

--- a/test/mcs/test_defmcs.jl
+++ b/test/mcs/test_defmcs.jl
@@ -225,4 +225,3 @@ trial2 = copy(sim2.rvdict[:name1].dist.values)
 
 @test length(trial1) == length(trial2)
 @test trial1 != trial2
-

--- a/test/mcs/test_defmcs.jl
+++ b/test/mcs/test_defmcs.jl
@@ -11,7 +11,6 @@ using Test
 using Mimi: reset_compdefs, modelinstance, compinstance, 
             get_var_value, OUTER, INNER, ReshapedDistribution
 
-reset_compdefs()
 include("../../examples/tutorial/02-two-region-model/two-region-model.jl")
 using .MyModel
 m = construct_MyModel()
@@ -44,7 +43,6 @@ sim = @defsim begin
     # assignment of RVs, above.
     save(grosseconomy.K, grosseconomy.YGROSS, emissions.E, emissions.E_Global)
 end
-
 
 
 # Optionally, user functions can be called just before or after a trial is run


### PR DESCRIPTION
- Added methods to manipulate a `Simulation` instance
- Eliminated `sim.dist_rvs`
- Changed uses of `sim.dist_rvs` to call `values(sim.rvdict)`

See also my comments in #474 