### PR TITLE
Make ntimesteps a keyword arg for run(MarginalModel)

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -184,7 +184,7 @@ function create_marginal_model(base::Model, delta::Float64=1.0)
     mm = MarginalModel(base, delta)
 end
 
-function Base.run(mm::MarginalModel, ntimesteps::Int=typemax(Int))
+function Base.run(mm::MarginalModel; ntimesteps::Int=typemax(Int))
     run(mm.base, ntimesteps=ntimesteps)
     run(mm.marginal, ntimesteps=ntimesteps)
 end


### PR DESCRIPTION
The `run` function for a normal Mimi model has `ntimesteps` as a keyword argument.

The `run` function for a MarginalModel had it not as a keyword argument. I'm guessing we should add in this semicolon so that it's the same type of option for running a MarginalModel. Thoughts?