### PR TITLE
Add julia 1.2 to CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 1.1
+  - 1.2
   - nightly
 dist: xenial
 services:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:


### PR DESCRIPTION
A release candidate was just released, so we can start testing on 1.2 regularly.