### PR TITLE
Add support for creating an empty Simulation

### DIFF
--- a/src/mcs/defmcs.jl
+++ b/src/mcs/defmcs.jl
@@ -165,7 +165,7 @@ macro defsim(expr)
         # TBD: need to generalize this to support other methods
         return :(Simulation{$simdatatype}(
                     [$(_rvs...)],
-                    [$(_transforms...)],  
+                    TransformSpec[$(_transforms...)],  
                     Tuple{Symbol, Symbol}[$(_saves...)],
                     $data))
     end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -162,6 +162,15 @@ mutable struct Simulation{T}
 end
 
 """
+    Simulation{T}() where T <: AbstractSimulationData
+
+Allow creation of an "empty" Simulation instance.
+"""
+function Simulation{T}() where T <: AbstractSimulationData
+    Simulation{T}([], TransformSpec[], Tuple{Symbol, Symbol}[], T())
+end
+
+"""
     set_payload!(sim::Simulation, payload) 
 
 Attach a user's `payload` to the `Simulation` instance so it can be


### PR DESCRIPTION
Made it possible to call `sim = Simulation()` and use the new API to populate `sim`.