### PR TITLE
Fix bug in inner scenario results saving

### DIFF
--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -493,12 +493,12 @@ function run_sim(sim::Simulation{T};
                 _restore_sim_params!(sim, original_values)
 
                 counter += 1
-                ProgressMeter.update!(p, counter)                
-            end
-
-            if has_inner_scenario && has_output_dir
-                save_trial_results(sim, output_dir)
-                _reset_results!(sim)
+                ProgressMeter.update!(p, counter)  
+                
+                if has_inner_scenario && has_output_dir
+                    save_trial_results(sim, output_dir)
+                    _reset_results!(sim)
+                end              
             end
         end
 


### PR DESCRIPTION
@rjplevin I think this was a bug in saving results, only the results for the last loop were being saved in the last of the tuples ... I'm fixing it it the bigger PR for the Sim API but thought we should just push out the bug fix now too