### PR TITLE
number_type Array conversion bug

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -340,7 +340,7 @@ function set_external_array_param!(md::ModelDef, name::Symbol, value::AbstractAr
     if !(typeof(value) <: Array{numtype})
         numtype = number_type(md)
         # Need to force a conversion (simple convert may alias in v0.6)
-        value = Array{numtype}(undef, value)
+        value = Array{numtype}(value)
     end
     param = ArrayModelParameter(value, dims === nothing ? Vector{Symbol}() : dims)
     set_external_param!(md, name, param)


### PR DESCRIPTION
I think this was a bug. All tests passed locally with this change. I found this when trying to use DualNumbers as the number_type, and external parameter data get converted from `Array{Float64}` to `Array{Dual{Float64}}` on this line