### PR TITLE
WIP Support for MarginalModels in running simulations

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -190,3 +190,8 @@ function Base.run(mm::MarginalModel; ntimesteps::Int=typemax(Int))
     run(mm.base, ntimesteps=ntimesteps)
     run(mm.marginal, ntimesteps=ntimesteps)
 end
+
+function build(mm::MarginalModel)
+    build(mm.base)
+    build(mm.marginal)
+end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -243,6 +243,7 @@ Return the dimension names for the variable or parameter `datum_name`
 in the given component `comp_name` in model `m`.
 """
 dimensions(m::Model, comp_name::Symbol, datum_name::Symbol) = dimensions(compdef(m, comp_name), datum_name)
+dimensions(mm::MarginalModel, comp_name::Symbol, datum_name::Symbol) = dimensions(compdef(mm.base, comp_name), datum_name)
 
 @modelegate dimension(m::Model, dim_name::Symbol) => md
 

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -159,7 +159,7 @@ mutable struct SimulationInstance{T}
     current_trial::Int
     current_data::Any               # holds data for current_trial when current_trial > 0
     sim_def::SimulationDef{T} where T <: AbstractSimulationData
-    models::Vector{Model}
+    models::Vector{Union{Model, MarginalModel}}
     results::Vector{Dict{Tuple, DataFrame}}
     payload::Any
 
@@ -172,7 +172,7 @@ mutable struct SimulationInstance{T}
         self.payload = deepcopy(self.sim_def.payload)
 
         # These are parallel arrays; each model has a corresponding results dict
-        self.models = Vector{Model}(undef, 0)
+        self.models = Vector{Union{Model, MarginalModel}}(undef, 0)
         self.results = [Dict{Tuple, DataFrame}()]
 
         return self

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -50,7 +50,7 @@ end
 
 # Store results for a single parameter and return the dataframe for this particular
 # trial/scenario 
-function _store_param_results(m::Model, datum_key::Tuple{Symbol, Symbol}, trialnum::Int, scen_name::Union{Nothing, String}, results::Dict{Tuple, DataFrame})
+function _store_param_results(m::Union{Model, MarginalModel}, datum_key::Tuple{Symbol, Symbol}, trialnum::Int, scen_name::Union{Nothing, String}, results::Dict{Tuple, DataFrame})
     @debug "\nStoring trial results for $datum_key"
 
     (comp_name, datum_name) = datum_key
@@ -228,8 +228,11 @@ function _copy_sim_params(sim_inst::SimulationInstance{T}) where T <: AbstractSi
     param_vec = Vector{Dict{Symbol, ModelParameter}}(undef, length(sim_inst.models))
 
     for (i, m) in enumerate(sim_inst.models)
-        md = m.mi.md
-        param_vec[i] = Dict{Symbol, ModelParameter}(trans.paramname => copy(external_param(md, trans.paramname)) for trans in sim_inst.sim_def.translist)
+        # If it's a MarginalModel, need to save a separate param_vec for the base and marginal models
+        mds = m isa MarginalModel ? [m.base.mi.md, m.marginal.mi.md] : [m.mi.md]
+        for md in mds
+            param_vec[i] = Dict{Symbol, ModelParameter}(trans.paramname => copy(external_param(md, trans.paramname)) for trans in sim_inst.sim_def.translist)
+        end
     end
 
     return param_vec
@@ -237,7 +240,18 @@ end
 
 function _restore_sim_params!(sim_inst::SimulationInstance{T}, 
                               param_vec::Vector{Dict{Symbol, ModelParameter}}) where T <: AbstractSimulationData
-    for (m, params) in zip(sim_inst.models, param_vec)
+    # Need to flatten the list of models so that if there is a MarginalModel,
+    #   both its base and marginal models will have their separate params restored
+    flat_model_list = [] 
+    for m in sim_inst.models
+        if m isa MarginalModel
+            push!(flat_model_list, m.base)
+            push!(flat_model_list, m.marginal)
+        else
+            push!(flat_model_list, m)
+        end
+    end
+    for (m, params) in zip(flat_model_list, param_vec)
         md = m.mi.md
         for trans in sim_inst.sim_def.translist
             name = trans.paramname
@@ -333,11 +347,14 @@ function _perturb_params!(sim_inst::SimulationInstance{T}, trialnum::Int) where 
     trialdata = get_trial(sim_inst, trialnum)
 
     for m in sim_inst.models
-        md = m.mi.md
-        for trans in sim_inst.sim_def.translist        
-            param = external_param(md, trans.paramname)
-            rvalue = getfield(trialdata, trans.rvname)
-            _perturb_param!(param, md, trans, rvalue)
+        # If it's a MarginalModel, need to perturb the params in both the base and marginal modeldefs
+        mds = m isa MarginalModel ? [m.base.mi.md, m.marginal.mi.md] : [m.mi.md]
+        for md in mds
+            for trans in sim_inst.sim_def.translist        
+                param = external_param(md, trans.paramname)
+                rvalue = getfield(trialdata, trans.rvname)
+                _perturb_param!(param, md, trans, rvalue)
+            end
         end
     end
     return nothing
@@ -368,7 +385,9 @@ function _compute_output_dir(orig_output_dir, tup)
 end
 
 """
-    run(sim_def::SimulationDef{T}, models::Union{Vector{Model}, Model, MarginalModel}, samplesize::Int; 
+    run(sim_def::SimulationDef{T}, 
+            models::Union{Vector{Model}, Vector{MarginalModel}, Vector{Union{Model, MarginalModel}}, Model, MarginalModel}, 
+            samplesize::Int; 
             ntimesteps::Int=typemax(Int), 
             trials_output_filename::Union{Nothing, AbstractString}=nothing, 
             results_output_dir::Union{Nothing, AbstractString}=nothing, 
@@ -415,16 +434,23 @@ Returns the type `SimulationInstance` that contains a copy of the original `Simu
 along with mutated information about trials, in addition to the model list and 
 results information.
 """
-function Base.run(sim_def::SimulationDef{T}, models::Union{Vector{Model}, Model}, samplesize::Int;
-                 ntimesteps::Int=typemax(Int), 
-                 trials_output_filename::Union{Nothing, AbstractString}=nothing, 
-                 results_output_dir::Union{Nothing, AbstractString}=nothing, 
-                 pre_trial_func::Union{Nothing, Function}=nothing, 
-                 post_trial_func::Union{Nothing, Function}=nothing,
-                 scenario_func::Union{Nothing, Function}=nothing,
-                 scenario_placement::ScenarioLoopPlacement=OUTER,
-                 scenario_args=nothing,
-                 results_in_memory::Bool=true) where T <: AbstractSimulationData
+function Base.run(sim_def::SimulationDef{T}, 
+                models::Union{Vector{Model}, Vector{MarginalModel}, Vector{Any}, Model, MarginalModel}, 
+                samplesize::Int;
+                ntimesteps::Int=typemax(Int), 
+                trials_output_filename::Union{Nothing, AbstractString}=nothing, 
+                results_output_dir::Union{Nothing, AbstractString}=nothing, 
+                pre_trial_func::Union{Nothing, Function}=nothing, 
+                post_trial_func::Union{Nothing, Function}=nothing,
+                scenario_func::Union{Nothing, Function}=nothing,
+                scenario_placement::ScenarioLoopPlacement=OUTER,
+                scenario_args=nothing,
+                results_in_memory::Bool=true) where T <: AbstractSimulationData
+
+    # If the provided models list has both a Model and a MarginalModel, it will be a Vector{Any}, and needs to be converted
+    if models isa Vector{Any}
+        models = convert(Vector{Union{Model, MarginalModel}}, models)
+    end
             
     # Quick check for results saving
     if (!results_in_memory) && (results_output_dir===nothing)
@@ -444,7 +470,11 @@ function Base.run(sim_def::SimulationDef{T}, models::Union{Vector{Model}, Model}
     end
 
     for m in sim_inst.models
-        if m.mi === nothing
+        if m isa MarginalModel
+            if m.base.mi === nothing || m.marginal.mi === nothing
+                build(m)
+            end
+        elseif m.mi === nothing
             build(m)
         end
     end
@@ -563,30 +593,23 @@ end
 
 # Set models
 """ 
-	    set_models!(sim_inst::SimulationInstance{T}, models::Vector{Model})
+	    set_models!(sim_inst::SimulationInstance{T}, models::Union{Vector{Model}, Vector{MarginalModel}, Vector{Union{Model, MarginalModel}}})
 	
 	Set the `models` to be used by the SimulationDef held by `sim_inst`. 
 """
-function set_models!(sim_inst::SimulationInstance{T}, models::Vector{Model}) where T <: AbstractSimulationData
+function set_models!(sim_inst::SimulationInstance{T}, models::Union{Vector{Model}, Vector{MarginalModel}, Vector{Union{Model, MarginalModel}}}) where T <: AbstractSimulationData
     sim_inst.models = models
     _reset_results!(sim_inst)    # sets results vector to same length
 end
 
 # Convenience methods for single model and MarginalModel
 """ 
-set_models!(sim_inst::SimulationInstance{T}, m::Model)
+set_models!(sim_inst::SimulationInstance{T}, m::Union{Model, MarginalModel})
 	
     Set the model `m` to be used by the Simulatoin held by `sim_inst`.
 """
-set_models!(sim_inst::SimulationInstance{T}, m::Model)  where T <: AbstractSimulationData = set_models!(sim_inst, [m])
+set_models!(sim_inst::SimulationInstance{T}, m::Union{Model, MarginalModel})  where T <: AbstractSimulationData = set_models!(sim_inst, [m])
 
-""" 
-set_models!(sim::SimulationInstance{T}, mm::MarginalModel)
-
-    Set the models to be used by the SimulationDef held by `sim_inst` to be `mm.base` and `mm.marginal`
-	which make up the MarginalModel `mm`. 
-"""
-set_models!(sim_inst::SimulationInstance{T}, mm::MarginalModel) where T <: AbstractSimulationData = set_models!(sim_inst, [mm.base, mm.marginal])
 
 #
 # Iterator functions for Simulation instance directly, and for use as an IterableTable.

--- a/test/mcs/runtests.jl
+++ b/test/mcs/runtests.jl
@@ -17,4 +17,7 @@ using Test
 
     @info("test_payload.jl")
     include("test_payload.jl")
+
+    @info("test_marginalmodel.jl")
+    include("test_marginalmodel.jl")
 end

--- a/test/mcs/test_marginalmodel.jl
+++ b/test/mcs/test_marginalmodel.jl
@@ -1,0 +1,51 @@
+using Mimi
+using Distributions
+using Test
+
+include("test-model/test-model.jl")
+using .TestModel
+
+m = create_model()
+mm1 = create_marginal_model(create_model())
+mm2 = create_marginal_model(create_model())
+
+simdef = @defsim begin
+    share = Uniform(0, 1)
+    save(emissions.E_Global)
+end
+
+# Test running one MarginalModel
+
+function post_trial1(si, trialnum, ntimesteps, tup)
+    @test length(si.models) == 1
+    @test si.models[1] isa MarginalModel
+end
+
+si = run(simdef, mm1, 2, post_trial_func = post_trial1, results_in_memory = true)
+@test all(iszero, si.results[1][:emissions, :E_Global][!, :E_Global])   # Test that the marginal emission saved from the MarginalModel are zeros (because there's no difference between mm.base and mm.marginal)
+
+
+# Test running a vector of MarginalModels
+
+function post_trial2(si, trialnum, ntimesteps, tup)
+    @test length(si.models) == 2
+    @test si.models[1] isa MarginalModel
+    @test si.models[2] isa MarginalModel
+end
+
+si = run(simdef, [mm1, mm2], 2, post_trial_func = post_trial2, results_in_memory = true)
+@test all(iszero, si.results[1][:emissions, :E_Global][!, :E_Global])  # Test that the regular model has non-zero emissions
+@test all(iszero, si.results[2][:emissions, :E_Global][!, :E_Global])   # Test that the marginal emission saved from the MarginalModel are zeros (because there's no difference between mm.base and mm.marginal)
+
+
+# Test running a vector of a Model and a MarginalModel
+
+function post_trial3(si, trialnum, ntimesteps, tup)
+    @test length(si.models) == 2
+    @test si.models[1] isa Model
+    @test si.models[2] isa MarginalModel
+end
+
+si = run(simdef, [m, mm1], 2, post_trial_func = post_trial3, results_in_memory = true)
+@test all(!iszero, si.results[1][:emissions, :E_Global][!, :E_Global])  # Test that the regular model has non-zero emissions
+@test all(iszero, si.results[2][:emissions, :E_Global][!, :E_Global])   # Test that the marginal emission saved from the MarginalModel are zeros (because there's no difference between mm.base and mm.marginal)


### PR DESCRIPTION
These changes allow `MarginalModels` in a simulation instance's list of models. Previously, a `MarginalModel` `mm` would be "flattened" into two models `mm.base` and `mm.marginal` in the list of models. Now, if a user provides a MarginalModel to the `run` function, then accessing the list of models from a simulation instance will yield the exact same list of models and/or MarginalModels. 

This functionality is demonstrated in a new test file: "test/mcs/test_marginalmodels.jl".