### PR TITLE
WIP: Allow Indexing into a Variable/Parameter with a Year

### DIFF
--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -239,6 +239,20 @@ function Base.getindex(v::TimestepVector{VariableTimestep{D_TIMES}, T}, ts::Vari
 	_missing_data_check(data)
 end
 
+function Base.getindex(v::TimestepVector{FixedTimestep{FIRST, STEP, LAST}, T}, ts::Timestep) where {T, FIRST, STEP, LAST} 
+
+	t = findfirst(isequal.(ts.value + ts.offset_in_timesteps, [first:step:last...]))
+	t === nothing ? error("cannot get data for year $(ts.value), time is not in the list of time values "): data = v.data[t]
+	_missing_data_check(data)
+end
+
+function Base.getindex(v::TimestepVector{VariableTimestep{TIMES}, T}, ts::Timestep) where {T, TIMES}
+	t = findfirst(isequal.(ts.value + ts.offset_in_timesteps, TIMES))
+	t === nothing ? error("cannot get data for year $(ts.value), time is not in the list of time values "): data = v.data[t]
+	data = v.data[t]
+	_missing_data_check(data)
+end
+
 # int indexing version supports old-style components and internal functions, not
 # part of the public API
 

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -22,6 +22,15 @@ struct VariableTimestep{TIMES} <: AbstractTimestep
     end
 end
 
+struct Timestep <: AbstractTimestep
+    value::Int
+    offset_in_timesteps::Int
+
+    function Timestep(v::Int, offset_in_timesteps::Int=0)
+        return new(v, offset_in_timesteps)
+    end
+end
+
 mutable struct Clock{T <: AbstractTimestep}
 	ts::T
 


### PR DESCRIPTION
UPDATE: CLOSING THIS PR TO START FRESH

#549, #568, #337 

This PR will handle a few different Issues related to indexing into a Variable or Parameter.

- [ ] create the two new types
- [ ] add `Base.:+` and `Base.:-` methods for the two types
- [ ] add `getindex` methods to `TimestepArray`, `TimestepVector`, and `TimestepMatrix`
- [ ] deprecate int indexing (#568)
- [ ] take a look at #337 
- [ ] `time_index`
- [ ] tests and documentation
