### PR TITLE
Change getindex to getdataframe for sim_inst

### DIFF
--- a/docs/src/internals/montecarlo.md
+++ b/docs/src/internals/montecarlo.md
@@ -163,10 +163,10 @@ If provided, the generated trials and results will be saved in the indicated
 `trials_output_filename` and `results_output_dir` respectively. If `results_in_memory` is set
 to false, then results will be cleared from memory and only stored in the
 `results_output_dir`. After `run`, the results of a `SimulationInstance` can be accessed using
-the familiar `getindex` function with the following signature, which returns a `DataFrame`. 
+the familiar `getdataframe` function with the following signature, which returns a `DataFrame`. 
 
 ```
-Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
+getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
 ```
 
 If `pre_trial_func` or `post_trial_func` are defined, the designated functions are called 
@@ -331,7 +331,7 @@ N = 100
 si = run(sd, m, N; trials_output_filename=trials_output_filename, results_output_dir=results_output_dir)
 
 # take a look at the results
-results = si[:grosseconomy, :K] # model index chosen defaults to 1
+results = getdataframe(si, :grosseconomy, :K) # model index chosen defaults to 1
 ```
 
 ## Plotting and the Explorer UI

--- a/docs/src/internals/montecarlo.md
+++ b/docs/src/internals/montecarlo.md
@@ -163,7 +163,7 @@ If provided, the generated trials and results will be saved in the indicated
 `trials_output_filename` and `results_output_dir` respectively. If `results_in_memory` is set
 to false, then results will be cleared from memory and only stored in the
 `results_output_dir`. After `run`, the results of a `SimulationInstance` can be accessed using
-the familiar `getdataframe` function with the following signature, which returns a `DataFrame`. 
+the `getdataframe` function with the following signature, which returns a `DataFrame`. 
 
 ```
 getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)

--- a/docs/src/tutorials/tutorial_4.md
+++ b/docs/src/tutorials/tutorial_4.md
@@ -119,7 +119,7 @@ Here, we first employ `run` to obtain results:
 si = run(sd, m, 100; trials_output_filename = "/tmp/trialdata.csv", results_output_dir="/tmp/Mimi")
 
 # Explore the results saved in-memory
-results = si[:grosseconomy, :K] # model index chosen defaults to 1
+results = getdataframe(si, :grosseconomy, :K) # model index chosen defaults to 1
 ```
 
 and then again using our user-defined post-trial function as the `post_trial_func` parameter:
@@ -129,7 +129,7 @@ and then again using our user-defined post-trial function as the `post_trial_fun
 si = run(sd, m, 100; trials_output_filename = "/tmp/trialdata.csv", results_output_dir="/tmp/Mimi", post_trial_func=print_result)
 
 # Explore the results saved in-memory
-results = si[:grosseconomy, :K] # model index chosen defaults to 1
+results = getdataframe(si, :grosseconomy, :K) # model index chosen defaults to 1
 ```
 
 ### Step 5. Explore and Plot Results

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -70,7 +70,7 @@ include("core/order.jl")
 include("core/paths.jl")
 include("core/show.jl")
 
-include("mcs/mcs.jl") # need mcs types for explorer
+include("mcs/mcs.jl") # need mcs types for explorer and utils
 include("explorer/explore.jl")
 include("utils/getdataframe.jl")
 include("utils/graph.jl")

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -230,5 +230,5 @@ function getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_nam
 end
 
 function getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
-    Error("getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead")
+    error("getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead")
 end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -229,6 +229,6 @@ function getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_nam
     return sim_inst.results[model][(comp_name, datum_name)]
 end
 
-function getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
+function Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
     error("getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead")
 end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -228,3 +228,7 @@ end
 function getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
     return sim_inst.results[model][(comp_name, datum_name)]
 end
+
+function getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
+    Error("getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead")
+end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -225,6 +225,6 @@ struct SimIterator{NT, T}
     end
 end
 
-function Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
+function getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
     return sim_inst.results[model][(comp_name, datum_name)]
 end

--- a/test/mcs/test_defmcs.jl
+++ b/test/mcs/test_defmcs.jl
@@ -72,13 +72,13 @@ function show_E_Global(year::Int; bins=40)
               xlabel="Emissions")
 end
 
-# test getindex
+# test getdataframe
 results_mem = si.results[1][(:grosseconomy, :K)] # manual access to dictionary
-results_getindex = si[:grosseconomy, :K] # Base.getindex
-results_getindex2 = si[:grosseconomy, :K, model = 1] # Base.getindex
+results_getdataframe = getdataframe(si, :grosseconomy, :K) # getdataframe
+results_getdataframe2 = getdataframe(si, :grosseconomy, :K, model = 1) # getdataframe
 
-@test results_getindex == results_mem
-@test results_getindex2 == results_mem
+@test results_getdataframe == results_mem
+@test results_getdataframe2 == results_mem
 
 # test that disk results equal in memory results
 results_disk = load(joinpath(output_dir, "grosseconomy_K.csv")) |> DataFrame
@@ -123,10 +123,10 @@ si = run(sd, m, N;
  
 @test loop_counter == 6
 
-# test getindex with scenarios
+# test getdataframe with scenarios
 results_mem = si.results[1][(:grosseconomy, :K)] # manual access to dictionary
-results_getindex = si[:grosseconomy, :K] # Base.getindex
-@test results_getindex == results_mem
+results_getdataframe = getdataframe(si, :grosseconomy, :K) # getdataframe
+@test results_getdataframe == results_mem
 
 # test in memory results compared to disk saved results
 results_disk = load(joinpath(output_dir, "high_0.03", "grosseconomy_K.csv")) |> DataFrame


### PR DESCRIPTION
This PR handles Issue #572.

Remove the `getindex` method for `SimulationInstance`and replace it with `getdataframe`.  Users will be able to use `getdataframe` to access results of a simulation while we do some thinking on what type we'd like `getindex` to return and how to handle the multidimensionality of scenarios etc.