### PR TITLE
Make d.time return AbstractTimesteps

### DIFF
--- a/src/core/instances.jl
+++ b/src/core/instances.jl
@@ -283,13 +283,14 @@ function Base.run(mi::ModelInstance, ntimesteps::Int=typemax(Int),
         time_keys = time_keys[1:ntimesteps]
     end
 
-    # TBD: Pass this, but substitute t from above?
-    dim_val_dict = DimValueDict(dim_dict(mi.md))
+    clock = Clock(time_keys)
+
+    # Get the dimensions dictionary
+    dim_val_dict = DimValueDict(dim_dict(mi.md), clock)
 
     # recursively initializes all components
     init(mi, dim_val_dict)
 
-    clock = Clock(time_keys)
     while ! finished(clock)
         run_timestep(mi, clock, dim_val_dict)
         advance(clock)

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -172,3 +172,13 @@ function Base.reset(c::Clock)
 	c.ts = c.ts - (c.ts.t - 1)
 	nothing
 end
+
+function Base.collect(c::Clock)
+	c = deepcopy(c)
+	timesteps = AbstractTimestep[]
+	while !finished(c)
+		push!(timesteps, c.ts)
+		advance(c)
+	end
+	return timesteps
+end

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -173,7 +173,7 @@ function Base.reset(c::Clock)
 	nothing
 end
 
-function Base.collect(c::Clock)
+function timesteps(c::Clock)
 	c = deepcopy(c)
 	timesteps = AbstractTimestep[]
 	while !finished(c)

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -177,7 +177,7 @@ function Base.collect(c::Clock)
 	c = deepcopy(c)
 	timesteps = AbstractTimestep[]
 	while !finished(c)
-		push!(timesteps, c.ts)
+		push!(timesteps, timestep(c))
 		advance(c)
 	end
 	return timesteps

--- a/src/core/types/instances.jl
+++ b/src/core/types/instances.jl
@@ -49,11 +49,15 @@ end
 
 # A container class that wraps the dimension dictionary when passed to run_timestep()
 # and init(), so we can safely implement Base.getproperty(), allowing `d.regions` etc.
+# All values in the dictionary are vectors of Ints, except the `:time` value, which is a 
+# vector of AbstractTimesteps, so that `d.time` returns values that can be used for indexing
+# into timestep arrays.
 struct DimValueDict <: MimiStruct
-    dict::Dict{Symbol, Vector{Int}}
+    dict::Dict{Symbol, Union{Vector{Int}, Vector{AbstractTimestep}}}
 
-    function DimValueDict(dim_dict::AbstractDict)
-        d = Dict([name => collect(values(dim)) for (name, dim) in dim_dict])
+    function DimValueDict(dim_dict::AbstractDict, clock::Clock)
+        vector_of_timesteps = collect(clock)
+        d = Dict([name => (name == :time ? vector_of_timesteps : collect(values(dim))) for (name, dim) in dim_dict])
         new(d)
     end
 end

--- a/src/core/types/instances.jl
+++ b/src/core/types/instances.jl
@@ -56,7 +56,7 @@ struct DimValueDict <: MimiStruct
     dict::Dict{Symbol, Union{Vector{Int}, Vector{AbstractTimestep}}}
 
     function DimValueDict(dim_dict::AbstractDict, clock::Clock)
-        d = Dict([name => (name == :time ? collect(clock) : collect(values(dim))) for (name, dim) in dim_dict])
+        d = Dict([name => (name == :time ? timesteps(clock) : collect(values(dim))) for (name, dim) in dim_dict])
         new(d)
     end
 end

--- a/src/core/types/instances.jl
+++ b/src/core/types/instances.jl
@@ -56,8 +56,7 @@ struct DimValueDict <: MimiStruct
     dict::Dict{Symbol, Union{Vector{Int}, Vector{AbstractTimestep}}}
 
     function DimValueDict(dim_dict::AbstractDict, clock::Clock)
-        vector_of_timesteps = collect(clock)
-        d = Dict([name => (name == :time ? vector_of_timesteps : collect(values(dim))) for (name, dim) in dim_dict])
+        d = Dict([name => (name == :time ? collect(clock) : collect(values(dim))) for (name, dim) in dim_dict])
         new(d)
     end
 end

--- a/test/test_dimensions.jl
+++ b/test/test_dimensions.jl
@@ -118,4 +118,32 @@ set_dimension!(m, :time, 2010:2050)
 @test first_period(m.md) == 2010
 @test last_period(m.md)  == 2050
 
+
+# Test that d.time returns AbstracTimesteps that can be used as indexes
+
+@defcomp bar begin
+    v1 = Variable(index = [time])
+
+    function run_timestep(p, v, d, t)
+        if is_first(t)
+            for i in d.time
+                v.v1[i] = gettime(i)
+            end
+        end
+    end
+end
+
+fixed_years = 2000:2010
+variable_years = [2000, 2005, 2020, 2050, 2100]
+
+m = Model()
+set_dimension!(m, :time, fixed_years)
+add_comp!(m, bar)
+run(m)
+@test m[:bar, :v1] == fixed_years
+
+set_dimension!(m, :time, variable_years)
+run(m)
+@test m[:bar, :v1] == variable_years
+
 end #module


### PR DESCRIPTION
Issue #538 

The `DimValueDict` previously held vectors of Ints for each dimension (keyed by a Symbol for the name of the dimension). Now, I've changed it so that the `:time` entry in this dictionary holds a vector of `AbstractTimestep`'s, so that calls to `d.time` in the `run_timestep` functions return timesteps that can be used for indexing into parameters and variables. There is only one place in the code where a `DimValueDict` object is constructed, and that is in the `run` function so that it can be passed to the `run_timestep` function.

Questions:
1. What I've implemented here was to modify the constructor of a `DimValueDict` to also take in the `Clock` object from which the `:time` vector of timesteps is created and stored in the dictionary (instead of a vector of Ints). Alternatively, I could have left the `DimValueDict` constructor untouched, so that it still would only hold vectors of Ints for each dimension, and then instead I would have to replace the `:time` entry of the `dim_value_dict` within the `run` function before it gets passed to `run_timestep` (there was a comment in the `run` function that you'll see I deleted, that I think was considering this alternative approach). I think I prefer the way I have implemented it here though, since the `DimValueDict` type only gets used for this one purpose, and also because we would still have to modify the type of the `dict` field to be `Dict{Symbol, Union{Vector{Int}, Vector{AbstractTimestep}}}` so that we could modify the `:time` entry afterward. But I am open to doing it the other way if you think that would be better!
2. Are you okay with this `Base.collect(clock::Clock)` function I implemented here to get the vector of timesteps that go into the dictionary, or should I call it something else?
3. How I've implemented this is to have `d.time` return the vector of timesteps that the Clock was going to run for. I think this is what we want users to have access to during `run_timetsep`, but I could be wrong, and maybe we want users to have access to the full time dimension, even if the model is being run for a shorter amount of time. I think @davidanthoff should give input here.
4. I added a minimal test to the "test_dimensions.jl" file, let me know if you think there is a better place to put these new tests!