### PR TITLE
Fix bug in add_connector_comps on master

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -596,6 +596,7 @@ end
 
 function add_connector_comps!(obj::AbstractCompositeComponentDef)
     conns = internal_param_conns(obj)
+    i = 1 # counter to track the number of connector comps added 
 
     for comp_def in compdefs(obj)
         comp_name = nameof(comp_def)
@@ -607,7 +608,7 @@ function add_connector_comps!(obj::AbstractCompositeComponentDef)
 
         # isempty(need_conn_comps) || @info "Need connectors comps: $need_conn_comps"
 
-        for (i, conn) in enumerate(need_conn_comps)
+        for conn in need_conn_comps
             add_backup!(obj, conn.backup)
 
             num_dims = length(size(external_param(obj, conn.backup).values))
@@ -619,7 +620,8 @@ function add_connector_comps!(obj::AbstractCompositeComponentDef)
             # Fetch the definition of the appropriate connector commponent
             conn_comp_def = (num_dims == 1 ? Mimi.ConnectorCompVector : Mimi.ConnectorCompMatrix)
             conn_comp_name = connector_comp_name(i) # generate a new name
-
+            i += 1 # increment connector comp counter
+            
             # Add the connector component before the user-defined component that required it
             conn_comp = add_comp!(obj, conn_comp_def, conn_comp_name, before=comp_name)
             conn_path = conn_comp.comp_path


### PR DESCRIPTION
#646 This PR fixes a bug in the `add_connector_comps!` function on master, where we have currently disabled functionality surrounding components with different lengths ... but this is a bug we will want to track and fix anyways unless we remove the function all together.  I'd suggest merging this fix for now.