### PR TITLE
Fix parameter type bug for non-time arrays

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -463,12 +463,6 @@ Add an array type parameter `name` with value `value` and `dims` dimensions to t
 """
 function set_external_array_param!(obj::AbstractCompositeComponentDef,
                                    name::Symbol, value::AbstractArray, dims)
-    numtype = Union{Missing, number_type(obj)}
-
-    if !(typeof(value) <: Array{numtype} || (value isa AbstractArray && eltype(value) <: numtype))
-        # Need to force a conversion (simple convert may alias in v0.6)
-        value = Array{numtype}(value)
-    end
     param = ArrayModelParameter(value, dims === nothing ? Vector{Symbol}() : dims)
     set_external_param!(obj, name, param)
 end

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -51,6 +51,7 @@ eval(expr)  # Just a deprecation warning for v0.10, then will change to error in
     f = Parameter{Array{Float64, 2}}()
     g = Parameter{Int}(default=10.0)    # value should be Int despite Float64 default
     h = Parameter(default=10)           # should be "numtype", despite Int default
+    j::Int = Parameter(index = [regions])
     
     function run_timestep(p, v, d, t)
     end
@@ -71,6 +72,7 @@ set_param!(m, :MyComp, :c, [4,5,6])
 set_param!(m, :MyComp, :d, 0.5)   # 32-bit float constant
 set_param!(m, :MyComp, :e, [1,2,3,4])
 set_param!(m, :MyComp, :f, reshape(1:16, 4, 4))
+set_param!(m, :MyComp, :j, [1,2,3])
 
 extpars = external_params(m)
 
@@ -103,7 +105,7 @@ update_param!(m, :d, 5) # should work, will convert to float
 @test_throws ErrorException update_param!(m, :e, ones(10)) # wrong size
 update_param!(m, :e, [4,5,6,7])
 
-@test length(extpars) == 8
+@test length(extpars) == 9
 @test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, arrtype, 1}
 @test typeof(extpars[:d].value) == numtype
 @test typeof(extpars[:e].values) == Array{arrtype, 1}


### PR DESCRIPTION
@jrising found this bug, more info on this forum post:
https://forum.mimiframework.org/t/array-parameter-setting-fails-with-int64-parameter-type/113

I added a line to the test file which now passes, but represents what previously would have errored. 