### PR TITLE
Improve int indexing depwarn msg

### DIFF
--- a/src/core/time_arrays.jl
+++ b/src/core/time_arrays.jl
@@ -56,16 +56,29 @@ function _single_index_check(data, idxs)
 	end
 end
 
+# Helper to print stacktrace
+function _get_stacktrace_string()
+	s = ""
+	for line in stacktrace()
+		s = string(s, line, "\n")
+	end
+	return s
+end
+
 # Helper functionfor getindex; throws an error if one indexes into a TimestepArray with an integer
 function _throw_int_getindex_depwarning()
-	msg = "Indexing with getindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]"
-	Base.depwarn("$msg, $(stacktrace())", :getindex)
+	msg = "Indexing with getindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]\n"
+	st = _get_stacktrace_string()
+	full_msg = string(msg, " \n", st)
+	Base.depwarn(full_msg, :getindex)
 end
 
 # Helper function for setindex; throws an deprecation warning if one indexes into a TimestepArray with an integer
 function _throw_int_setindex_depwarning()
 	msg = "Indexing with setindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndec(2)]"
-	Base.depwarn("$msg, $(stacktrace())", :setindex)
+	st = _get_stacktrace_string()
+	full_msg = string(msg, " \n", st)
+	Base.depwarn(full_msg, :setindex!)
 end
 
 # Helper macro used by connector

--- a/src/core/time_arrays.jl
+++ b/src/core/time_arrays.jl
@@ -58,13 +58,15 @@ end
 
 # Helper to print stacktrace for the integer indexing deprecatino warning
 function _get_stacktrace_string()
-
 	s = ""
 	for line in stacktrace()
-		s = string(s, line, "\n")
-		if startswith(string(line), "macro expansion") # return as soon as you hit a macro expand
-			return s
+		line_string = string(line)
+		if startswith(line_string, "run_timestep") # shorten calls to run_timestep
+			l = "run_timestep function call"
+		else
+			l = line_string
 		end
+		s = string(s, l, "\n")
 	end
 	return s
 end

--- a/src/core/time_arrays.jl
+++ b/src/core/time_arrays.jl
@@ -61,7 +61,7 @@ function _get_stacktrace_string()
 	s = ""
 	for line in stacktrace()
 		line_string = string(line)
-		if startswith(line_string, "run_timestep") # shorten calls to run_timestep
+		if startswith(line_string, "run_timestep") # shorten the reporting on calls to run_timestep
 			l = "run_timestep function call"
 		else
 			l = line_string

--- a/src/core/time_arrays.jl
+++ b/src/core/time_arrays.jl
@@ -60,13 +60,11 @@ end
 function _get_stacktrace_string()
 	s = ""
 	for line in stacktrace()
-		line_string = string(line)
-		if startswith(line_string, "run_timestep") # shorten the reporting on calls to run_timestep
-			l = "run_timestep function call"
+		if startswith(string(line), "run_timestep")
+			return s
 		else
-			l = line_string
+			s = string(s, line, "\n")
 		end
-		s = string(s, l, "\n")
 	end
 	return s
 end

--- a/src/core/time_arrays.jl
+++ b/src/core/time_arrays.jl
@@ -56,11 +56,15 @@ function _single_index_check(data, idxs)
 	end
 end
 
-# Helper to print stacktrace
+# Helper to print stacktrace for the integer indexing deprecatino warning
 function _get_stacktrace_string()
+
 	s = ""
 	for line in stacktrace()
 		s = string(s, line, "\n")
+		if startswith(string(line), "macro expansion") # return as soon as you hit a macro expand
+			return s
+		end
 	end
 	return s
 end


### PR DESCRIPTION
This PR addresses #690, and improves the error message for the deprecation warning associated with integer indexing. Since the Stacktrace will change in each call, the improvement for now prints out the `stacktrace()` stack frame line by line instead of as a text block, ie. the following.

The component printout could still be quite long, however, but at least printed nicely.

```
┌ Warning: Indexing with getindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]
│  
│ _get_stacktrace_string() at time_arrays.jl:62
│ _throw_int_getindex_depwarning at time_arrays.jl:71 [inlined]
│ getindex(::TimestepArray{FixedTimestep{2000,1,LAST} where LAST,Int64,1,1}, ::Int64) at time_arrays.jl:209
│ top-level scope at REPL[68]:1
│ eval(::Module, ::Any) at boot.jl:331
│ eval_user_input(::Any, ::REPL.REPLBackend) at REPL.jl:86
│ macro expansion at REPL.jl:118 [inlined]
│ (::REPL.var"#26#27"{REPL.REPLBackend})() at task.jl:358
│   caller = top-level scope at REPL[68]:1
└ @ Core REPL[68]:1
```
