### PR TITLE
fix `_fix_comp_path!` for internal connections

### DIFF
--- a/src/core/paths.jl
+++ b/src/core/paths.jl
@@ -47,8 +47,8 @@ function _fix_comp_path!(child::AbstractComponentDef, parent::AbstractCompositeC
         # Fix internal param conns
         conns = child.internal_param_conns
         for (i, conn) in enumerate(conns)
-            src_path = ComponentPath(child_path, tail(conn.src_comp_path))
-            dst_path = ComponentPath(child_path, tail(conn.dst_comp_path))
+            src_path = ComponentPath(child_path, conn.src_comp_path.names[end])
+            dst_path = ComponentPath(child_path, conn.dst_comp_path.names[end])
 
             # @info "Resetting IPC src in $child_path from $(conn.src_comp_path) to $src_path"
             # @info "Resetting IPC dst in $child_path from $(conn.dst_comp_path) to $dst_path"

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -161,6 +161,16 @@ end
 
 top2_ref = add_comp!(m2, top2, nameof(top2))
 
+#
+# Test _fix_comp_path on internal connections 3 levels down
+#
+
+@defcomposite top3 begin
+    Component(top)
+end
+
+@test top3[:top][:A].internal_param_conns[1].src_comp_path == Mimi.ComponentPath(:top3, :top, :A, :Comp1)
+
 end # module
 
 nothing

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -171,6 +171,10 @@ end
 
 @test top3[:top][:A].internal_param_conns[1].src_comp_path == Mimi.ComponentPath(:top3, :top, :A, :Comp1)
 
+path1 = ComponentPath(:a, :b)
+path2 = ComponentPath(:c, :d)
+@test ComponentPath(path1, path2) == ComponentPath(:a, :b, :c, :d)
+
 end # module
 
 nothing


### PR DESCRIPTION
#689 
The problem was that `tail(comp_path)` returns not just the last element, it returns everything but the head. But what we want here is just the last element.