### PR TITLE
Datum access

### DIFF
--- a/docs/src/internals/structures_3_instances.md
+++ b/docs/src/internals/structures_3_instances.md
@@ -18,8 +18,8 @@ run_timestep::Union{Nothing, Function}
 
 # CompositeComponentInstance <: ComponentInstance
 comps_dict::OrderedDict{Symbol, ComponentInstance}
-pars_dict::OrderedDict{Symbol, Any}   # not currently being used but, probably should for better datum access
-vars_dict::OrderedDict{Symbol, Any}   # ^ same
+parameters::NamedTuple
+variables::NamedTuple
 
 # ModelInstance <: CompositeComponentInstance
 md::ModelDef

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -241,9 +241,10 @@ function _instantiate_params(comp_def::ComponentDef, par_dict::Dict{Tuple{Compon
     return ComponentInstanceParameters(names, types, vals, paths)
 end
 
-function _instantiate_params(comp_def::AbstractCompositeComponentDef, par_dict::Dict{Tuple{ComponentPath, Symbol}, Any})
-    _combine_exported_pars(comp_def)
-end
+# LFR: commented out because potentially doing nothing ... never called
+# function _instantiate_params(comp_def::AbstractCompositeComponentDef, par_dict::Dict{Tuple{ComponentPath, Symbol}, Any})
+#     _combine_exported_pars(comp_def)
+# end
 
 # Return a built leaf or composite LeafComponentInstance
 function _build(comp_def::ComponentDef,
@@ -269,6 +270,11 @@ function _build(comp_def::AbstractCompositeComponentDef,
     # @info "  par_dict $(par_dict)"
 
     comps = [_build(cd, var_dict, par_dict, time_bounds) for cd in compdefs(comp_def)]
+
+    # LFR TODO
+    # vars_dict = get_vars_dict(comp_def)
+    # pars_dict = get_pars_dict(comp_def)
+    
     return CompositeComponentInstance(comps, comp_def, time_bounds)
 end
 

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -271,11 +271,26 @@ function _build(comp_def::AbstractCompositeComponentDef,
 
     comps = [_build(cd, var_dict, par_dict, time_bounds) for cd in compdefs(comp_def)]
 
-    # LFR TODO
-    variables = NamedTuple(Tuple(:var1, :var2), Tuple(1.0, 2.0))
-    parameters = NamedTuple(Tuple(:par1, :par2), Tuple(1.0, 2.0))
+    variables = _get_variables(comp_def, var_dict)
+    parameters = _get_parameters(comp_def, par_dict)
 
     return CompositeComponentInstance(comps, comp_def, time_bounds, variables, parameters)
+end
+
+# helper functions for to create the variables and parameters NamedTuples for a 
+# CompositeComponentInstance
+function _get_variables(comp_def::AbstractCompositeComponentDef, var_dict::Dict{ComponentPath, Any})
+
+    # TODO (dummy below)
+    NT = NamedTuple(Tuple(:var1, :var2), Tuple(1.0, 2.0))
+    return NT
+end
+
+function _get_parameters(comp_def::AbstractCompositeComponentDef, par_dict::Dict{Tuple{ComponentPath, Symbol}, Any})
+
+    # TODO (dummy below)
+    NT = NamedTuple(Tuple(:par1, :par2), Tuple(1.0, 2.0))
+    return NT
 end
 
 """

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -241,7 +241,7 @@ function _instantiate_params(comp_def::ComponentDef, par_dict::Dict{Tuple{Compon
     return ComponentInstanceParameters(names, types, vals, paths)
 end
 
-# LFR: commented out because potentially doing nothing ... never called
+# commented out because potentially doing nothing ... the fcn is never called
 # function _instantiate_params(comp_def::AbstractCompositeComponentDef, par_dict::Dict{Tuple{ComponentPath, Symbol}, Any})
 #     _combine_exported_pars(comp_def)
 # end
@@ -272,10 +272,10 @@ function _build(comp_def::AbstractCompositeComponentDef,
     comps = [_build(cd, var_dict, par_dict, time_bounds) for cd in compdefs(comp_def)]
 
     # LFR TODO
-    # vars_dict = get_vars_dict(comp_def)
-    # pars_dict = get_pars_dict(comp_def)
-    
-    return CompositeComponentInstance(comps, comp_def, time_bounds)
+    variables = NamedTuple(Tuple(:var1, :var2), Tuple(1.0, 2.0))
+    parameters = NamedTuple(Tuple(:par1, :par2), Tuple(1.0, 2.0))
+
+    return CompositeComponentInstance(comps, comp_def, time_bounds, variables, parameters)
 end
 
 """

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -77,14 +77,6 @@ function _instantiate_component_vars(md::ModelDef, comp_def::ComponentDef)
     return ComponentInstanceVariables(names, types, values, paths)
 end
 
-function _combine_exported_pars(comp_def::AbstractCompositeComponentDef)
-    names  = Symbol[]
-    values = Any[]
-    paths = repeat(Any[comp_def.comp_path], length(names))
-    types = DataType[typeof(val) for val in values]
-    return ComponentInstanceParameters(names, types, values, paths)
-end
-
 # Creates the top-level vars for the model
 function _instantiate_vars(md::ModelDef)
     vdict = Dict{ComponentPath, Any}()
@@ -240,11 +232,6 @@ function _instantiate_params(comp_def::ComponentDef, par_dict::Dict{Tuple{Compon
 
     return ComponentInstanceParameters(names, types, vals, paths)
 end
-
-# commented out because potentially doing nothing ... the fcn is never called
-# function _instantiate_params(comp_def::AbstractCompositeComponentDef, par_dict::Dict{Tuple{ComponentPath, Symbol}, Any})
-#     _combine_exported_pars(comp_def)
-# end
 
 # Return a built leaf or composite LeafComponentInstance
 function _build(comp_def::ComponentDef,

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -271,26 +271,34 @@ function _build(comp_def::AbstractCompositeComponentDef,
 
     comps = [_build(cd, var_dict, par_dict, time_bounds) for cd in compdefs(comp_def)]
 
-    variables = _get_variables(comp_def, var_dict)
-    parameters = _get_parameters(comp_def, par_dict)
+    variables = _get_variables(comp_def)
+    parameters = _get_parameters(comp_def)
 
     return CompositeComponentInstance(comps, comp_def, time_bounds, variables, parameters)
 end
 
 # helper functions for to create the variables and parameters NamedTuples for a 
 # CompositeComponentInstance
-function _get_variables(comp_def::AbstractCompositeComponentDef, var_dict::Dict{ComponentPath, Any})
+function _get_variables(comp_def::AbstractCompositeComponentDef)
 
-    # TODO (dummy below)
-    NT = NamedTuple(Tuple(:var1, :var2), Tuple(1.0, 2.0))
-    return NT
+    namespace = comp_def.namespace
+    var_defs = filter(namespace -> isa(namespace.second, CompositeVariableDef), namespace)
+    names = [k for (k,v) in var_defs]
+    vals = [v.ref for (k,v) in var_defs]
+    variables = (; zip(names, vals)...)
+    
+    return variables
 end
 
-function _get_parameters(comp_def::AbstractCompositeComponentDef, par_dict::Dict{Tuple{ComponentPath, Symbol}, Any})
+function _get_parameters(comp_def::AbstractCompositeComponentDef)
 
-    # TODO (dummy below)
-    NT = NamedTuple(Tuple(:par1, :par2), Tuple(1.0, 2.0))
-    return NT
+    namespace = comp_def.namespace
+    par_defs = filter(namespace -> isa(namespace.second, CompositeParameterDef), namespace)
+    names = [k for (k,v) in par_defs]
+    vals = [v.refs[1] for (k,v) in par_defs]
+    parameters = (; zip(names, vals)...)
+
+    return parameters
 end
 
 """

--- a/src/core/instances.jl
+++ b/src/core/instances.jl
@@ -168,8 +168,9 @@ function Base.getindex(obj::AbstractCompositeComponentInstance, comp_name::Symbo
     return compinstance(obj, comp_name)
 end
 
-# TBD: some of this is very similar to _get_datum for leaf component instance, 
-# but in some ways it seems clearner to separate them
+# TBD we could probably combine the two _get_datum methods into one that takes a
+# ci::AbstractComponentInstance, but for now it seems there are enough differences
+# that keeping them separate is cleaner
 function _get_datum(ci::CompositeComponentInstance, datum_name::Symbol)
     vars = variables(ci)
 
@@ -187,7 +188,6 @@ function _get_datum(ci::CompositeComponentInstance, datum_name::Symbol)
     ref = getproperty(which, datum_name)
     
     return _get_datum(ci.comps_dict[ref.comp_name], ref.datum_name)
-
 end
 
 function _get_datum(ci::LeafComponentInstance, datum_name::Symbol)

--- a/src/core/instances.jl
+++ b/src/core/instances.jl
@@ -185,13 +185,9 @@ function _get_datum(ci::CompositeComponentInstance, datum_name::Symbol)
     end
     
     ref = getproperty(which, datum_name)
-    leaf_comp_name = ref.comp_name
-    leaf_datum_name = ref.datum_name
     
-    # LFR TODO figure out which path to go down to find the leaf
-    # next_comp_name = 
-    # next_datum_name = 
-    return _get_datum(ci.comps_dict[next_comp_name, next_datum_name])
+    # LFR TODO get the comp_name and datum_name to use ...
+    return _get_datum(ci.comps_dict[comp_name, datum_name])
 
 end
 

--- a/src/core/instances.jl
+++ b/src/core/instances.jl
@@ -168,16 +168,16 @@ function Base.getindex(obj::AbstractCompositeComponentInstance, comp_name::Symbo
     return compinstance(obj, comp_name)
 end
 
-# LFR TODO some of this is very similar to _get_datum for leaf component instance, 
+# TBD: some of this is very similar to _get_datum for leaf component instance, 
 # but in some ways it seems clearner to separate them
 function _get_datum(ci::CompositeComponentInstance, datum_name::Symbol)
     vars = variables(ci)
 
-    if datum_name in keys(vars) # could merge with below if made names(NamedTuple) = keys(NamedTuple)
+    if datum_name in keys(vars) # could merge with method below if made names(NamedTuple) = keys(NamedTuple)
         which = vars
     else
         pars = parameters(ci)
-        if datum_name in keys(pars) # could merge with below if made names(NamedTuple) = keys(NamedTuple)
+        if datum_name in keys(pars) # could merge with method below if made names(NamedTuple) = keys(NamedTuple)
             which = pars
         else
             error("$datum_name is not a parameter or a variable in component $(ci.comp_path).")
@@ -186,8 +186,7 @@ function _get_datum(ci::CompositeComponentInstance, datum_name::Symbol)
     
     ref = getproperty(which, datum_name)
     
-    # LFR TODO get the comp_name and datum_name to use ...
-    return _get_datum(ci.comps_dict[comp_name, datum_name])
+    return _get_datum(ci.comps_dict[ref.comp_name], ref.datum_name)
 
 end
 
@@ -214,7 +213,6 @@ function Base.getindex(mi::ModelInstance, key::AbstractString, datum::Symbol)
     _get_datum(mi[key], datum)
 end
 
-# LFR TODO: does this get used? should we keep it?
 function Base.getindex(obj::AbstractCompositeComponentInstance, comp_name::Symbol, datum::Symbol)
     ci = obj[comp_name]
     return _get_datum(ci, datum)

--- a/src/core/types/instances.jl
+++ b/src/core/types/instances.jl
@@ -189,8 +189,8 @@ end
 
 @class mutable CompositeComponentInstance <: ComponentInstance begin
     comps_dict::OrderedDict{Symbol, AbstractComponentInstance}
-    var_dict::OrderedDict{Symbol, Any}
-    par_dict::OrderedDict{Symbol, Any}
+    var_dict::OrderedDict{Symbol, UnnamedReference}
+    par_dict::OrderedDict{Symbol, UnnamedReference}
 
     function CompositeComponentInstance(self::AbstractCompositeComponentInstance,
                                         comps::Vector{<: AbstractComponentInstance},
@@ -203,8 +203,9 @@ end
             comps_dict[ci.comp_name] = ci
         end
 
-        var_dict = OrderedDict{Symbol, Any}()
-        par_dict = OrderedDict{Symbol, Any}()
+        # LFR TODO - will pass in the pardict and vardict from build
+        # var_dict = OrderedDict{Symbol, Any}()
+        # par_dict = OrderedDict{Symbol, Any}()
 
         ComponentInstance(self, comp_def, time_bounds, name)
         CompositeComponentInstance(self, comps_dict, var_dict, par_dict)

--- a/src/core/types/instances.jl
+++ b/src/core/types/instances.jl
@@ -214,8 +214,10 @@ end
     function CompositeComponentInstance(comps::Vector{<: AbstractComponentInstance},
                                         comp_def::AbstractCompositeComponentDef,
                                         time_bounds::Tuple{Int,Int},
+                                        variables::NamedTuple, 
+                                        parameters::NamedTuple,
                                         name::Symbol=nameof(comp_def))
-        CompositeComponentInstance(new(), comps, comp_def, time_bounds, name)
+        CompositeComponentInstance(new(), comps, comp_def, time_bounds, variables, parameters, name)
     end
 end
 

--- a/src/core/types/instances.jl
+++ b/src/core/types/instances.jl
@@ -189,13 +189,15 @@ end
 
 @class mutable CompositeComponentInstance <: ComponentInstance begin
     comps_dict::OrderedDict{Symbol, AbstractComponentInstance}
-    var_dict::OrderedDict{Symbol, UnnamedReference}
-    par_dict::OrderedDict{Symbol, UnnamedReference}
+    variables::NamedTuple
+    parameters::NamedTuple
 
     function CompositeComponentInstance(self::AbstractCompositeComponentInstance,
                                         comps::Vector{<: AbstractComponentInstance},
                                         comp_def::AbstractCompositeComponentDef,
                                         time_bounds::Tuple{Int,Int},
+                                        variables::NamedTuple, 
+                                        parameters::NamedTuple,
                                         name::Symbol=nameof(comp_def))
 
         comps_dict = OrderedDict{Symbol, AbstractComponentInstance}()
@@ -203,12 +205,8 @@ end
             comps_dict[ci.comp_name] = ci
         end
 
-        # LFR TODO - will pass in the pardict and vardict from build
-        # var_dict = OrderedDict{Symbol, Any}()
-        # par_dict = OrderedDict{Symbol, Any}()
-
         ComponentInstance(self, comp_def, time_bounds, name)
-        CompositeComponentInstance(self, comps_dict, var_dict, par_dict)
+        CompositeComponentInstance(self, comps_dict, variables, parameters)
         return self
     end
 

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -158,6 +158,7 @@ end
 @test mi["/top/B/Comp4", :par_4_1] == collect(6.0:6:96.0)
 
 @test m[:top, :fooA1] == 1
+@test m[:top, :foo3] == 10
 @test m[:top, :var_3_1] == collect(6.0:6:96.0)
 
 # vars

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -161,8 +161,6 @@ end
 @test m[:top, :foo3] == 10
 @test m[:top, :var_3_1] == collect(6.0:6:96.0)
 
-# vars
-
 # Test joining external params.
 #
 m2 = Model()

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -6,7 +6,7 @@ using Mimi
 import Mimi:
     ComponentId, ComponentPath, ComponentDef, AbstractComponentDef,
     CompositeComponentDef, ModelDef, build, time_labels, compdef, find_comp,
-    import_params!
+    import_params!, CompositeVariableDef, CompositeParameterDef
 
 @defcomp Comp1 begin
     par_1_1 = Parameter(index=[time])      # external input
@@ -138,12 +138,24 @@ run(m)
 
 mi = m.mi
 
+# test access methods
 @test mi[:top][:A][:Comp2, :par_2_2] == collect(1.0:16.0)
 @test mi["/top/A/Comp2", :par_2_2] == collect(1.0:16.0)
 
 @test mi["/top/A/Comp2", :var_2_1] == collect(3.0:3:48.0)
 @test mi["/top/A/Comp1", :var_1_1] == collect(1.0:16.0)
 @test mi["/top/B/Comp4", :par_4_1] == collect(6.0:6:96.0)
+
+# test parameters and variables fields of CompositeComponentInstance
+top_var_keys = keys(mi[:top].variables)
+top_par_keys = keys(mi[:top].parameters)
+for item in md[:top].namespace
+    if isa(item.second, CompositeVariableDef)
+        @test in(item.first, top_var_keys)
+    elseif isa(item.second, CompositeParameterDef)
+        @test in(item.first, top_par_keys)
+    end
+end
 
 #
 # Test joining external params.

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -88,7 +88,7 @@ end
     foo3 = Parameter(B.foo3)
     foo4 = Parameter(B.foo4)
 
-    var_3_1 = Variable(B.Comp3.var_3_1)
+    var_3_1 = Variable(B.var_3_1)
 
     connect(B.par_3_1, A.var_2_1)
     connect(B.par_4_1, B.var_3_1)
@@ -138,14 +138,6 @@ run(m)
 
 mi = m.mi
 
-# test access methods
-@test mi[:top][:A][:Comp2, :par_2_2] == collect(1.0:16.0)
-@test mi["/top/A/Comp2", :par_2_2] == collect(1.0:16.0)
-
-@test mi["/top/A/Comp2", :var_2_1] == collect(3.0:3:48.0)
-@test mi["/top/A/Comp1", :var_1_1] == collect(1.0:16.0)
-@test mi["/top/B/Comp4", :par_4_1] == collect(6.0:6:96.0)
-
 # test parameters and variables fields of CompositeComponentInstance
 top_var_keys = keys(mi[:top].variables)
 top_par_keys = keys(mi[:top].parameters)
@@ -157,7 +149,19 @@ for item in md[:top].namespace
     end
 end
 
-#
+# test access methods
+@test mi[:top][:A][:Comp2, :par_2_2] == collect(1.0:16.0)
+@test mi["/top/A/Comp2", :par_2_2] == collect(1.0:16.0)
+
+@test mi["/top/A/Comp2", :var_2_1] == collect(3.0:3:48.0)
+@test mi["/top/A/Comp1", :var_1_1] == collect(1.0:16.0)
+@test mi["/top/B/Comp4", :par_4_1] == collect(6.0:6:96.0)
+
+@test m[:top, :fooA1] == 1
+@test m[:top, :var_3_1] == collect(6.0:6:96.0)
+
+# vars
+
 # Test joining external params.
 #
 m2 = Model()


### PR DESCRIPTION
#677 

Currently we have implemented the methods and constructors needed to access parameters and variables in the top level composite components of a model with a call like

```
m[:top, :par_name
```
next steps are to add more comprehensive testing and think about corner cases like renaming.  also, do we want to be able to use this syntax for lower levels i.e. if `:B` is a child composite component of `:top` but not in the `comps_dict` of `m.mi`, should we be able to do 
```
m[:B, :par name]
```