### PR TITLE
Change deprecation warning to error for sim instance access methods

### DIFF
--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -197,8 +197,7 @@ macro defcomp(comp_name, ex)
 
         # DEPRECATION - EVENTUALLY REMOVE
         if @capture(elt, name_::datum_type_ = elt_type_(args__))
-            msg = "The following syntax has been deprecated in @defcomp: \"$name::$datum_type = $elt_type(...)\". Use curly bracket syntax instead: \"$name = $elt_type{$datum_type}(...)\""
-            error("$msg\n$(reduce((x,y) -> "$x\n$y")")  
+            error("The following syntax has been deprecated in @defcomp: \"$name::$datum_type = $elt_type(...)\". Use curly bracket syntax instead: \"$name = $elt_type{$datum_type}(...)\"")
         elseif ! @capture(elt, name_ = (elt_type_{datum_type_}(args__) | elt_type_(args__)))
         end
         

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -198,7 +198,7 @@ macro defcomp(comp_name, ex)
         # DEPRECATION - EVENTUALLY REMOVE
         if @capture(elt, name_::datum_type_ = elt_type_(args__))
             msg = "The following syntax has been deprecated in @defcomp: \"$name::$datum_type = $elt_type(...)\". Use curly bracket syntax instead: \"$name = $elt_type{$datum_type}(...)\""
-            error("$msg\n$(reduce((x,y) -> "$x\n$y", stacktrace()))")  
+            error("$msg\n$(reduce((x,y) -> "$x\n$y")")  
         elseif ! @capture(elt, name_ = (elt_type_{datum_type_}(args__) | elt_type_(args__)))
         end
         

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -171,10 +171,7 @@ new component specified by `comp_id`. Use the following syntax instead:
 See docstring for `replace!` for further description of available functionality.
 """
 function replace_comp!(m::Model, comp_id::ComponentId, comp_name::Symbol=comp_id.comp_name; kwargs...)
-    msg = "Function `replace_comp!(m, comp_id, comp_name; kwargs...)` has been deprecated. Use `replace!(m, comp_name => Mimi.compdef(comp_id); kwargs...)` instead."
-    st = _get_stacktrace_string()
-	full_msg = string(msg, " \n", st)
-	error(full_msg)
+    error("Function `replace_comp!(m, comp_id, comp_name; kwargs...)` has been deprecated. Use `replace!(m, comp_name => Mimi.compdef(comp_id); kwargs...)` instead.")
 end
 
 # DEPRECATION - EVENTUALLY REMOVE
@@ -194,10 +191,7 @@ new component specified by `comp_def`. Use the following syntax instead:
 See docstring for `replace!` for further description of available functionality.
 """
 function replace_comp!(m::Model, comp_def::ComponentDef, comp_name::Symbol=comp_def.comp_id.comp_name; kwargs...)
-    msg = "Function `replace_comp!(m, comp_def, comp_name; kwargs...)` has been deprecated. Use `replace!(m, comp_name => comp_def; kwargs...)` instead."
-    st = _get_stacktrace_string()
-	full_msg = string(msg, " \n", st)
-	error(full_msg)
+    error("Function `replace_comp!(m, comp_def, comp_name; kwargs...)` has been deprecated. Use `replace!(m, comp_name => comp_def; kwargs...)` instead.")
 end
 
 """

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -27,7 +27,7 @@ end
 Deprecated fucntion to return true or false, true if the current time (year) for `ts` is `t`
  """
  function is_time(ts::AbstractTimestep, t::Int) 
- 	error("`is_time(ts, t)` is deprecated. Use comparison operators with TimestepValue objects instead: `ts == TimestepValue(t)` \n$(stacktrace())", :is_time)
+ 	error("`is_time(ts, t)` is deprecated. Use comparison operators with TimestepValue objects instead: `ts == TimestepValue(t)`")
  end
 
 """
@@ -46,7 +46,7 @@ end
 Deprecated function to return true or false, true if `ts` timestep is step `t`.
  """
  function is_timestep(ts::AbstractTimestep, t::Int)
- 	error("`is_timestep(ts, t)` is deprecated. Use comparison operators with TimestepIndex objects instead: `ts == TimestepIndex(t)` \n$(stacktrace())", :is_timestep)
+ 	error("`is_timestep(ts, t)` is deprecated. Use comparison operators with TimestepIndex objects instead: `ts == TimestepIndex(t)`")
  end
 
 """

--- a/src/core/time_arrays.jl
+++ b/src/core/time_arrays.jl
@@ -58,35 +58,15 @@ function _single_index_check(data, idxs)
 end
 
 # DEPRECATION - EVENTUALLY REMOVE
-# Helper to print stacktrace for the integer indexing errors
-function _get_stacktrace_string()
-	s = ""
-	for line in stacktrace()
-		if startswith(string(line), "run_timestep")
-			return s
-		else
-			s = string(s, line, "\n")
-		end
-	end
-	return s
-end
-
-# DEPRECATION - EVENTUALLY REMOVE
 # Helper function for getindex; throws an error if one indexes into a TimestepArray with an integer
 function _throw_int_getindex_error()
-	msg = "Indexing with getindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]\n"
-	st = _get_stacktrace_string()
-	full_msg = string(msg, " \n", st)
-	error(full_msg)
+	error("Indexing with getindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]")
 end
 
 # DEPRECATION - EVENTUALLY REMOVE
 # Helper function for setindex; throws an error if one indexes into a TimestepArray with an integer
 function _throw_int_setindex_error()
-	msg = "Indexing with setindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]"
-	st = _get_stacktrace_string()
-	full_msg = string(msg, " \n", st)
-	error(full_msg)
+	error("Indexing with setindex into a TimestepArray with Integer(s) is deprecated, please index with a TimestepIndex(index::Int) instead ie. instead of t[2] use t[TimestepIndex(2)]")
 end
 
 # Helper macro used by connector

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -230,6 +230,5 @@ function getdataframe(sim_inst::SimulationInstance, comp_name::Symbol, datum_nam
 end
 
 function Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
-    msg = "getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead"
-    error("$msg")
+    error("getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead")
 end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -231,6 +231,6 @@ end
 
 function Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
     msg = "getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead"
-    error("$msg, $(stacktrace())", :getindex)
+    error("$msg, $(stacktrace())")
     return sim_inst.results[model][(comp_name, datum_name)]
 end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -231,6 +231,5 @@ end
 
 function Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
     msg = "getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead"
-    error("$msg, $(stacktrace())")
-    return sim_inst.results[model][(comp_name, datum_name)]
+    error("$msg")
 end

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -231,6 +231,6 @@ end
 
 function Base.getindex(sim_inst::SimulationInstance, comp_name::Symbol, datum_name::Symbol; model::Int = 1)
     msg = "getindex method for `SimulationInstance` has been replaced with getdataframe function for consistency of return type, please use getdataframe instead"
-    Base.depwarn("$msg, $(stacktrace())", :getindex)
+    error("$msg, $(stacktrace())", :getindex)
     return sim_inst.results[model][(comp_name, datum_name)]
 end


### PR DESCRIPTION
This deprecation warning needs to be an error for v1.0.0, I noticed this when working on PAGE.