### PR TITLE
Improve Code Coverage

### DIFF
--- a/docs/src/ref/ref_structures_2_definitions.md
+++ b/docs/src/ref/ref_structures_2_definitions.md
@@ -34,7 +34,6 @@ Composite components are defined using the `@defcomposite` macro which generates
 # CompositeComponentDef <: ComponentDef 
 internal_param_conns::Vector{InternalParameterConnection}   
 backups::Vector{Symbol}
-sorted_comps::Union{Nothing, Vector{Symbol}}
 ```
 The namespace of a composite component can hold `CompositeParameterDef`s and`CompositeVariableDef`s, as well as `AbstractComponentDef`s (which can be other leaf or composite component definitions).
 

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -75,7 +75,6 @@ include("mcs/mcs.jl") # need mcs types for explorer and utils
 include("explorer/explore.jl")
 include("utils/getdataframe.jl")
 include("utils/graph.jl")
-include("utils/lint_helper.jl")
 include("utils/misc.jl")
 include("utils/plotting.jl")
 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -632,8 +632,5 @@ function add_connector_comps!(obj::AbstractCompositeComponentDef)
         end
     end
 
-    # Save the sorted component order for processing
-    # obj.sorted_comps = _topological_sort(obj)
-
     return nothing
 end

--- a/src/core/order.jl
+++ b/src/core/order.jl
@@ -46,19 +46,3 @@ function comp_graph(md::ModelDef)
 
     return graph
 end
-
-"""
-    _topological_sort(md::ModelDef)
-
-Build a directed acyclic graph referencing the positions of the components in 
-the OrderedDict of model `md`, tracing dependencies to create the DAG.
-Perform a topological sort on the graph for the given model and return a vector 
-of component paths in the order that will ensure dependencies are processed 
-prior to dependent components.
-"""
-function _topological_sort(md::ModelDef)
-    graph = comp_graph(md)
-    ordered = topological_sort_by_dfs(graph)
-    paths = map(i -> graph[i, :path], ordered)
-    return paths
-end

--- a/src/core/types/defs.jl
+++ b/src/core/types/defs.jl
@@ -160,8 +160,6 @@ global const NamespaceElement          = Union{LeafNamespaceElement, CompositeNa
     backups::Vector{Symbol}
 
 
-    sorted_comps::Union{Nothing, Vector{Symbol}}
-
     function CompositeComponentDef(comp_id::Union{Nothing, ComponentId}=nothing)
         self = new()
         CompositeComponentDef(self, comp_id)
@@ -174,7 +172,6 @@ global const NamespaceElement          = Union{LeafNamespaceElement, CompositeNa
         self.comp_path = ComponentPath(self.name)
         self.internal_param_conns = Vector{InternalParameterConnection}()
         self.backups = Vector{Symbol}()
-        self.sorted_comps = nothing
     end
 end
 

--- a/src/utils/lint_helper.jl
+++ b/src/utils/lint_helper.jl
@@ -1,9 +1,0 @@
-function lint_helper(ex::Expr, ctx)
-    if ex.head == :macrocall
-        if ex.args[1] == Symbol("@defcomp")
-            push!(ctx.callstack[end].types, ex.args[2])
-            return true
-        end
-    end
-    return false
-end

--- a/test/test_plotting.jl
+++ b/test/test_plotting.jl
@@ -40,4 +40,7 @@ run(m)
 graph = plot_comp_graph(m)
 @test typeof(graph) == Mimi.Compose.Context
 
+graph = plot_comp_graph(m, joinpath(tempdir(), "plot.pdf"))
+@test typeof(graph) == Mimi.Compose.Context
+
 end #module

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -90,7 +90,6 @@ Model
             ...
             6: 0.0
           1: time
-    sorted_comps: nothing
     number_type: Float64
   mi: nothing"""   # ignore (most) whitespace
 


### PR DESCRIPTION
Some Notes

- take a look at graph.jl and what we actually need from there, and where the code belongs 
- can we delete these from references.jl since we don't do this type of chaining

```
# Methods to convert components, params, and vars to references
# for use with getproperty() chaining.

function _make_reference(obj::AbstractComponentDef, comp_ref::ComponentReference)
    return ComponentReference(parent(obj), nameof(obj))
end

function _make_reference(obj::VariableDef, comp_ref::ComponentReference)
    return VariableReference(comp_ref, obj.name)
end

function _make_reference(obj::ParameterDef, comp_ref::ComponentReference)
    return ParameterReference(comp_ref, obj.name)
end

function Base.getproperty(ref::ComponentReference, name::Symbol)
    comp = find_comp(ref)
    return _make_reference(getfield(comp, name), ref) # might be ref to comp, var, or param
end
```
