### PR TITLE
Cleanup build

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -336,16 +336,21 @@ function _build(md::ModelDef)
     return mi
 end
 
-function build!(m::Model)
-
+function build(m::Model)    
     # Reference a copy in the ModelInstance to avoid changes underfoot
     md = deepcopy(m.md)
     _set_defaults!(md)  # apply defaults to unset parameters in the model instance's copy of the model definition
     
-    m.mi = _build(md)
+    mi = _build(md)
+    return mi
+end
+
+function build!(m::Model)
+    m.mi = build(m)
     m.md.dirty = false
     return nothing
 end
+
 
 """
     create_marginal_model(base::Model, delta::Float64=1.0)

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -336,7 +336,7 @@ function _build(md::ModelDef)
     return mi
 end
 
-function build(m::Model)
+function build!(m::Model)
 
     # Reference a copy in the ModelInstance to avoid changes underfoot
     md = deepcopy(m.md)
@@ -358,7 +358,7 @@ function create_marginal_model(base::Model, delta::Float64=1.0)
     # Make sure the base has a ModelInstance before we copy since this
     # copies the ModelDef to avoid being affected by later changes.
     if ! is_built(base)
-        build(base)
+        build!(base)
     end
 
     # Create a marginal model, which shares the internal ModelDef between base and marginal
@@ -370,7 +370,7 @@ function Base.run(mm::MarginalModel; ntimesteps::Int=typemax(Int))
     run(mm.modified, ntimesteps=ntimesteps)
 end
 
-function build(mm::MarginalModel)
-    build(mm.base)
-    build(mm.modified)
+function build!(mm::MarginalModel)
+    build!(mm.base)
+    build!(mm.modified)
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -413,7 +413,7 @@ function Base.run(m::Model; ntimesteps::Int=typemax(Int), rebuild::Bool=false,
     end
 
     if (rebuild || ! is_built(m))
-        build(m)
+        build!(m)
     end
 
     # println("Running model...")

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -484,7 +484,7 @@ function Base.run(sim_def::SimulationDef{T},
     end
 
     for m in sim_inst.models
-        is_built(m) || build(m)
+        is_built(m) || build!(m)
     end
     
     trials = 1:sim_inst.trials

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -118,7 +118,7 @@ cd = compdef(m.md, :C)      # Get the component definition in the model
 #@test cd.last === nothing
 
 set_param!(m, :C, :par1, zeros(5))
-Mimi.build(m)               # Build the model
+Mimi.build!(m)               # Build the model
 ci = compinstance(m, :C) # Get the component instance
 @test ci.first == 2001      # The component instance's first and last values should match the model's index
 @test ci.last == 2005
@@ -131,7 +131,7 @@ cd = compdef(m.md, :C)       # Get the component definition in the model
 #@test cd.last === nothing
 
 update_param!(m, :par1, zeros(16); update_timesteps=true)
-Mimi.build(m)               # Build the model
+Mimi.build!(m)               # Build the model
 ci = compinstance(m, :C) # Get the component instance
 @test ci.first == 2005      # The component instance's first and last values should match the model's index
 @test ci.last == 2020
@@ -157,7 +157,7 @@ cd = compdef(m.md, :C)      # Get the component definition in the model
 set_dimension!(m, :time, 2010:2090)
 
 set_param!(m, :C, :par1, zeros(81))
-Mimi.build(m)               # Build the model
+Mimi.build!(m)               # Build the model
 ci = compinstance(m, :C) # Get the component instance
 @test ci.first == 2010      # The component instance's first and last values are the same as in the comp def
 @test ci.last == 2090
@@ -167,7 +167,7 @@ cd = compdef(m.md, :C)      # Get the component definition in the model
 # @test cd.first == 2010      # First and last values should still be the same
 # @test cd.last == 2090
 
-Mimi.build(m)               # Build the model
+Mimi.build!(m)               # Build the model
 ci = compinstance(m, :C) # Get the component instance
 # @test ci.first == 2010      # The component instance's first and last values are the same as the comp def
 # @test ci.last == 2090

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -5,7 +5,7 @@ using Mimi
 
 import Mimi:
     ComponentId, ComponentPath, ComponentDef, AbstractComponentDef,
-    CompositeComponentDef, ModelDef, build, time_labels, compdef, find_comp,
+    CompositeComponentDef, ModelDef, time_labels, compdef, find_comp,
     import_params!, CompositeVariableDef, CompositeParameterDef
 
 @defcomp Comp1 begin
@@ -132,7 +132,7 @@ set_param!(m, :foo4, 20)
 
 set_param!(m, :par_1_1, collect(1:length(time_labels(md))))
 
-build(m)
+Mimi.build!(m)
 
 run(m)
 

--- a/test/test_main.jl
+++ b/test/test_main.jl
@@ -5,7 +5,7 @@ using Mimi
 
 import Mimi: 
     reset_variables,
-    variable, variable_names, external_param, build, 
+    variable, variable_names, external_param,
     compdefs, dimension, compinstance
 
 @defcomp foo1 begin
@@ -48,7 +48,7 @@ set_param!(x1, :foo1, :par2, [true true false; true false false; true true true]
 
 set_param!(x1, :foo1, :par3, [1.0, 2.0, 3.0])
 
-build(x1)
+Mimi.build!(x1)
 
 ci = compinstance(x1, :foo1)
 reset_variables(ci)

--- a/test/test_main_variabletimestep.jl
+++ b/test/test_main_variabletimestep.jl
@@ -5,7 +5,7 @@ using Mimi
 
 import Mimi:
     reset_variables,
-    variable, variable_names, external_param, build,
+    variable, variable_names, external_param,
     compdef, compdefs, dimension, compinstance
 
 @defcomp foo1 begin
@@ -48,7 +48,7 @@ set_param!(x1, :foo1, :par2, [true true false; true false false; true true true]
 
 set_param!(x1, :foo1, :par3, [1.0, 2.0, 3.0])
 
-build(x1)
+Mimi.build!(x1)
 
 ci = compinstance(x1, :foo1)
 reset_variables(ci)

--- a/test/test_model_structure.jl
+++ b/test/test_model_structure.jl
@@ -6,7 +6,7 @@ using Test
 using Mimi
 
 import Mimi:
-    connect_param!, unconnected_params, set_dimension!,  build,
+    connect_param!, unconnected_params, set_dimension!,
     get_connections, internal_param_conns, dim_count,  dim_names,
     modeldef, modelinstance, compdef, getproperty, setproperty!, dimension, compdefs
 
@@ -134,7 +134,7 @@ delete!(m, :A)
 end
 
 add_comp!(m, D)
-@test_throws ErrorException build(m)
+@test_throws ErrorException Mimi.build!(m)
 
 ##########################################
 #   Test init function                   #

--- a/test/test_model_structure_variabletimestep.jl
+++ b/test/test_model_structure_variabletimestep.jl
@@ -134,6 +134,6 @@ delete!(m, :A)
 end
 
 add_comp!(m, D)
-@test_throws ErrorException Mimi.build(m)
+@test_throws ErrorException Mimi.build!(m)
 
 end # module

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -5,7 +5,7 @@ using Test
 
 import Mimi:
     external_params, external_param, TimestepMatrix, TimestepVector,
-    ArrayModelParameter, ScalarModelParameter, FixedTimestep, build, import_params!
+    ArrayModelParameter, ScalarModelParameter, FixedTimestep, import_params!
 
 #
 # Test that parameter type mismatches are caught
@@ -73,7 +73,7 @@ set_param!(m, :MyComp, :e, [1,2,3,4])
 set_param!(m, :MyComp, :f, reshape(1:16, 4, 4))
 set_param!(m, :MyComp, :j, [1,2,3])
 
-build(m)    # applies defaults, creating external params in the model instance's copied definition
+Mimi.build!(m)    # applies defaults, creating external params in the model instance's copied definition
 extpars = external_params(m.mi.md)
 
 @test isa(extpars[:a], ArrayModelParameter)


### PR DESCRIPTION
The `build` function we previously had in the codebase doesn't return anything, but instead just modifies the model that is passed. So as a mutating function, it should really be named `build!`. First commit in this PR here makes that rename. I think that should be safe, given that this is an internal function.

The second commit then adds a `build` function that returns a model instance from a `Model`, but doesn't modify the `Model` itself. That is essentially what is documented in https://www.mimiframework.org/Mimi.jl/stable/howto_advanced/howto_adv_buildinit/#The-Internal-'build'-Function-and-Model-Instances-1, but not implemented currently.

This is a first step to address https://github.com/mimiframework/Mimi.jl/issues/753. What we then still need is an `update_param!` that works purely on a `ModelInstance`, and I think then we should be good?