### PR TITLE
add `delete_unbound_comp_params` kwarg to `delete!`

### DIFF
--- a/docs/src/ref/ref_API.md
+++ b/docs/src/ref/ref_API.md
@@ -7,6 +7,7 @@ Model
 add_comp!  
 connect_param!
 create_marginal_model
+delete_param!
 dim_count
 dim_keys
 dim_key_dict

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -19,6 +19,7 @@ export
     # components,
     connect_param!,
     create_marginal_model,
+    delete_param!,
     dim_count,
     dim_keys,
     dim_key_dict,

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -96,6 +96,7 @@ function Base.delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_param
         epc_filter = x -> x.comp_path != comp_path
         filter!(epc_filter, md.external_param_conns)
     end
+    dirty!(md)
 end
 
 """
@@ -115,6 +116,7 @@ function delete_param!(md::ModelDef, external_param_name::Symbol; delete_connect
         epc_filter = x -> x.external_param != external_param_name
         filter!(epc_filter, md.external_param_conns)
     end
+    dirty!(md)
 end
 
 @delegate Base.haskey(comp::AbstractComponentDef, key::Symbol) => namespace

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -90,7 +90,7 @@ function Base.delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_param
         unbound_comp_params = filter(unbound_filter, comp_ext_params)
 
         # Delete these parameters (the delete_param! function also deletes the associated external_param_conns)
-        [delete_param!(md, param_name, delete_connections=true) for param_name in unbound_comp_params]
+        [delete_param!(md, param_name) for param_name in unbound_comp_params]
 
     else # only delete the external connections for this component but leave all external parameters
         epc_filter = x -> x.comp_path != comp_path
@@ -100,22 +100,22 @@ function Base.delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_param
 end
 
 """
-    delete_param!(md::ModelDef, external_param_name::Symbol; delete_connections::Bool=true)
+    delete_param!(md::ModelDef, external_param_name::Symbol)
 
-Delete `external_param_name` from `md`'s list of external parameters. If `delete_connections=true`,
-also remove all external parameters connections that were connected to `external_param_name`.
+Delete `external_param_name` from `md`'s list of external parameters, and also 
+remove all external parameters connections that were connected to `external_param_name`.
 """
-function delete_param!(md::ModelDef, external_param_name::Symbol; delete_connections::Bool=true)
+function delete_param!(md::ModelDef, external_param_name::Symbol)
     if external_param_name in keys(md.external_params)
         delete!(md.external_params, external_param_name)
     else
         error("Cannot delete $external_param_name, not found in external parameter list.")
     end
     
-    if delete_connections
-        epc_filter = x -> x.external_param != external_param_name
-        filter!(epc_filter, md.external_param_conns)
-    end
+    # Remove external parameter connections
+    epc_filter = x -> x.external_param != external_param_name
+    filter!(epc_filter, md.external_param_conns)
+
     dirty!(md)
 end
 

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -58,13 +58,13 @@ find_first_period(comp_def::AbstractComponentDef) = @or(first_period(comp_def), 
 find_last_period(comp_def::AbstractComponentDef) = @or(last_period(comp_def), last_period(get_root(comp_def)))
 
 """
-    delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_params::Bool=false)
+    delete!(md::ModelDef, comp_name::Symbol; deep::Bool=false)
 
 Delete a `component` by name from `md`.
-If `delete_unbound_comp_params=true` then any external model parameters connected only to 
+If `deep=true` then any external model parameters connected only to 
 this component will also be deleted.
 """
-function Base.delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_params::Bool=false)
+function Base.delete!(md::ModelDef, comp_name::Symbol; deep::Bool=false)
     if ! has_comp(md, comp_name)
         error("Cannot delete '$comp_name': component does not exist.")
     end
@@ -81,7 +81,7 @@ function Base.delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_param
 
     # Remove external parameter connections
 
-    if delete_unbound_comp_params # Find and delete external_params that were connected only to the deleted component if specified
+    if deep # Find and delete external_params that were connected only to the deleted component if specified
         # Get all external parameters this component is connected to
         comp_ext_params = map(x -> x.external_param, filter(x -> x.comp_path == comp_path, md.external_param_conns))
 

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -112,7 +112,7 @@ function delete_param!(md::ModelDef, external_param_name::Symbol; delete_connect
     end
     
     if delete_connections
-        epc_filter = x -> x.external_param == external_param_name
+        epc_filter = x -> x.external_param != external_param_name
         filter!(epc_filter, md.external_param_conns)
     end
 end

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -84,12 +84,10 @@ function Base.delete!(md::ModelDef, comp_name::Symbol; delete_unbound_comp_param
     if delete_unbound_comp_params # Find and delete external_params that were connected only to the deleted component if specified
         # Get all external parameters this component is connected to
         comp_ext_params = map(x -> x.external_param, filter(x -> x.comp_path == comp_path, md.external_param_conns))
-        println(comp_ext_params)
 
         # Identify which ones are not connected to any other components
         unbound_filter = x -> length(filter(epc -> epc.external_param == x, md.external_param_conns)) == 1
         unbound_comp_params = filter(unbound_filter, comp_ext_params)
-        println(unbound_comp_params)
 
         # Delete these parameters (the delete_param! function also deletes the associated external_param_conns)
         [delete_param!(md, param_name, delete_connections=true) for param_name in unbound_comp_params]

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -378,6 +378,14 @@ this component will also be deleted.
 @delegate Base.delete!(m::Model, comp_name::Symbol; delete_unbound_comp_params::Bool=false) => md
 
 """
+    delete_param!(m::Model, external_param_name::Symbol; delete_connections::Bool=true)
+
+Delete `external_param_name` from a model `m`'s ModelDef's list of external parameters. If `delete_connections=true`,
+also remove all external parameters connections that were connected to `external_param_name`.
+"""
+@delegate delete_param!(m::Model, external_param_name::Symbol; delete_connections::Bool=true) => md
+
+"""
     set_param!(m::Model, comp_name::Symbol, param_name::Symbol, value; dims=nothing)
 
 Set the parameter of a component `comp_name` in a model `m` to a given `value`.

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -378,12 +378,12 @@ this component will also be deleted.
 @delegate Base.delete!(m::Model, comp_name::Symbol; delete_unbound_comp_params::Bool=false) => md
 
 """
-    delete_param!(m::Model, external_param_name::Symbol; delete_connections::Bool=true)
+    delete_param!(m::Model, external_param_name::Symbol)
 
-Delete `external_param_name` from a model `m`'s ModelDef's list of external parameters. If `delete_connections=true`,
+Delete `external_param_name` from a model `m`'s ModelDef's list of external parameters, and
 also remove all external parameters connections that were connected to `external_param_name`.
 """
-@delegate delete_param!(m::Model, external_param_name::Symbol; delete_connections::Bool=true) => md
+@delegate delete_param!(m::Model, external_param_name::Symbol) => md
 
 """
     set_param!(m::Model, comp_name::Symbol, param_name::Symbol, value; dims=nothing)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -369,11 +369,13 @@ Add a scalar type parameter `name` with value `value` to the model `m`.
 @delegate set_external_scalar_param!(m::Model, name::Symbol, value::Any) => md
 
 """
-    delete!(m::Model, component::Symbol
+    delete!(m::Model, component::Symbol; delete_unbound_comp_params::Bool=false)
 
-Delete a `component`` by name from a model `m`'s ModelDef, and nullify the ModelInstance.
+Delete a `component` by name from a model `m`'s ModelDef, and nullify the ModelInstance.
+If `delete_unbound_comp_params=true` then any external model parameters connected only to 
+this component will also be deleted.
 """
-@delegate Base.delete!(m::Model, comp_name::Symbol) => md
+@delegate Base.delete!(m::Model, comp_name::Symbol; delete_unbound_comp_params::Bool=false) => md
 
 """
     set_param!(m::Model, comp_name::Symbol, param_name::Symbol, value; dims=nothing)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -369,13 +369,13 @@ Add a scalar type parameter `name` with value `value` to the model `m`.
 @delegate set_external_scalar_param!(m::Model, name::Symbol, value::Any) => md
 
 """
-    delete!(m::Model, component::Symbol; delete_unbound_comp_params::Bool=false)
+    delete!(m::Model, component::Symbol; deep::Bool=false)
 
 Delete a `component` by name from a model `m`'s ModelDef, and nullify the ModelInstance.
-If `delete_unbound_comp_params=true` then any external model parameters connected only to 
+If `deep=true` then any external model parameters connected only to 
 this component will also be deleted.
 """
-@delegate Base.delete!(m::Model, comp_name::Symbol; delete_unbound_comp_params::Bool=false) => md
+@delegate Base.delete!(m::Model, comp_name::Symbol; deep::Bool=false) => md
 
 """
     delete_param!(m::Model, external_param_name::Symbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,9 @@ Electron.prep_test_env()
     @info("test_model_structure_variabletimestep.jl")
     @time include("test_model_structure_variabletimestep.jl")
 
+    @info("test_delete.jl")
+    @time include("test_delete.jl")
+
     @info("test_replace_comp.jl")
     @time include("test_replace_comp.jl")
 

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -29,7 +29,7 @@ delete!(m1, :A1)
 @test length(Mimi.components(m1.md)) == 1
 @test length(m1.md.external_param_conns) == 2   # Component A1 deleted, so only two connections left
 @test length(m1.md.external_params) == 3        # but all three external params remain
-@test :p2_A1 in keys(m2.md.external_params)
+@test :p2_A1 in keys(m1.md.external_params)
 
 # Test component deletion that removes unbound component parameters
 m2 = _get_model()
@@ -38,4 +38,12 @@ delete!(m2, :A1, delete_unbound_comp_params = true)
 @test length(m2.md.external_params) == 2        # :p2_A1 has been removed
 @test !(:p2_A1 in keys(m2.md.external_params))
 
+# Test the `delete_param! function on its own
+m3 = _get_model()
+delete_param!(m3, :p1, delete_connections = false)
+@test length(m3.md.external_params) == 2
+@test length(m3.md.external_param_conns) == 4   # All connections still remain
+delete_param!(m3, :p2_A1, delete_connections = true)
+@test length(m3.md.external_params) == 1
+@test length(m3.md.external_param_conns) == 3   # All connections still remain
 end

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -44,11 +44,8 @@ delete!(m2, :A1, delete_unbound_comp_params = true)
 # Test the `delete_param! function on its own
 m3 = _get_model()
 run(m3)
-delete_param!(m3, :p1, delete_connections = false)
-@test_throws ErrorException run(m3)     # will error because there are connections that reference p1 
+delete_param!(m3, :p1)
+@test_throws ErrorException run(m3)     # will not be able to run because p1 in both components aren't connected to anything
 @test length(m3.md.external_params) == 2
-@test length(m3.md.external_param_conns) == 4   # All connections still remain
-delete_param!(m3, :p2_A1, delete_connections = true)
-@test length(m3.md.external_params) == 1
-@test length(m3.md.external_param_conns) == 3   # p2_A1 connection was deleted
+@test length(m3.md.external_param_conns) == 2   # The external param connections to p1 have also been removed
 end

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -45,5 +45,5 @@ delete_param!(m3, :p1, delete_connections = false)
 @test length(m3.md.external_param_conns) == 4   # All connections still remain
 delete_param!(m3, :p2_A1, delete_connections = true)
 @test length(m3.md.external_params) == 1
-@test length(m3.md.external_param_conns) == 3   # All connections still remain
+@test length(m3.md.external_param_conns) == 3   # p2_A1 connection was deleted
 end

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -1,6 +1,6 @@
 module TestDelete
 
-# Test the behavior of the `delete!` function with and without the `delete_unbound_comp_params` kwarg.
+# Test the behavior of the `delete!` function with and without the `deep` kwarg.
 
 using Mimi
 using Test
@@ -36,7 +36,7 @@ run(m1) # run before and after to test that `delete!` properly "dirties" the mod
 
 # Test component deletion that removes unbound component parameters
 m2 = _get_model()
-delete!(m2, :A1, delete_unbound_comp_params = true)
+delete!(m2, :A1, deep = true)
 @test length(Mimi.components(m2.md)) == 1
 @test length(m2.md.external_params) == 2        # :p2_A1 has been removed
 @test !(:p2_A1 in keys(m2.md.external_params))

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -1,0 +1,41 @@
+module TestDelete
+
+# Test the behavior of the `delete!` function with and without the `delete_unbound_comp_params` kwarg.
+
+using Mimi
+using Test
+
+@defcomp A begin
+    p1 = Parameter()
+    p2 = Parameter()
+end
+
+function _get_model()
+    m = Model()
+    add_comp!(m, A, :A1)
+    add_comp!(m, A, :A2)
+    set_param!(m, :p1, 1)
+    set_param!(m, :A1, :p2, :p2_A1, 21)
+    set_param!(m, :A2, :p2, :p2_A2, 22)
+    return m
+end
+
+# Test component deletion without removing unbound component parameters
+m1 = _get_model()
+@test length(Mimi.components(m1.md)) == 2
+@test length(m1.md.external_param_conns) == 4   # two components with two connections each
+@test length(m1.md.external_params) == 3        # three total external params 
+delete!(m1, :A1)
+@test length(Mimi.components(m1.md)) == 1
+@test length(m1.md.external_param_conns) == 2   # Component A1 deleted, so only two connections left
+@test length(m1.md.external_params) == 3        # but all three external params remain
+@test :p2_A1 in keys(m2.md.external_params)
+
+# Test component deletion that removes unbound component parameters
+m2 = _get_model()
+delete!(m2, :A1, delete_unbound_comp_params = true)
+@test length(Mimi.components(m2.md)) == 1
+@test length(m2.md.external_params) == 2        # :p2_A1 has been removed
+@test !(:p2_A1 in keys(m2.md.external_params))
+
+end


### PR DESCRIPTION
#752 

Two additions in this PR:
1. This adds `delete_unbound_comp_params::Bool=false` keyword argument to the `delete!` function, which when set to true then deletes all external parameters that were only connected to the deleted component. 
2. I also created a new function `delete_param!(m, external_param_name, delete_connections=true)` for removing parameters from a model's list of external parameters.

To discuss:

- kwarg name: I went with the verbose `delete_unbound_comp_params` for now, which is definitely not perfect. The reason I'm feeling averse to `deep` or `recursive` is that it doesn't delete _all_ parameters associated with this component, only the ones not connected to any other components.
- in order to add this functionality, I had to change the function signature to only operate on ModelDefs, and not on all AbstractCompositeComponentDefs because the latter do not have external parameter lists.
- for the new `delete_param!` function, is this okay to make the default `delete_connections=true`, and do we want a different name for that keyword arg?