### PR TITLE
fix ExternalParameterConnection bug in delete!

### DIFF
--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -89,13 +89,14 @@ function Base.delete!(md::ModelDef, comp_name::Symbol; deep::Bool=false)
         unbound_filter = x -> length(filter(epc -> epc.external_param == x, md.external_param_conns)) == 1
         unbound_comp_params = filter(unbound_filter, comp_ext_params)
 
-        # Delete these parameters (the delete_param! function also deletes the associated external_param_conns)
+        # Delete these parameters
         [delete_param!(md, param_name) for param_name in unbound_comp_params]
+    end        
 
-    else # only delete the external connections for this component but leave all external parameters
-        epc_filter = x -> x.comp_path != comp_path
-        filter!(epc_filter, md.external_param_conns)
-    end
+    # delete any external connections for this component
+    epc_filter = x -> x.comp_path != comp_path
+    filter!(epc_filter, md.external_param_conns)
+
     dirty!(md)
 end
 

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -40,6 +40,7 @@ delete!(m2, :A1, deep = true)
 @test length(Mimi.components(m2.md)) == 1
 @test length(m2.md.external_params) == 2        # :p2_A1 has been removed
 @test !(:p2_A1 in keys(m2.md.external_params))
+run(m2)
 
 # Test the `delete_param! function on its own
 m3 = _get_model()


### PR DESCRIPTION
when `deep=true` the ExternalParameterConnections for parameters that aren't being delete still need to be removed for the deleted component