### PR TITLE
Update timesteps bugfix

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -561,10 +561,10 @@ function _update_array_param!(obj::AbstractCompositeComponentDef, name, value)
             new_timestep_array = get_timestep_array(obj, T, N, ti, value)
             set_external_param!(obj, name, ArrayModelParameter(new_timestep_array, dim_names(param)))
         else
-            param.values.data = value
+            copyto!(param.values.data, value)
         end
     else
-        param.values = value
+        copyto!(param.values, value)
     end
 
     dirty!(obj)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -580,9 +580,10 @@ symbol matching the name of an external parameter that already exists in the
 component definition.
 """
 function update_params!(obj::AbstractCompositeComponentDef, parameters::Dict; update_timesteps = nothing)
+    !isnothing(update_timesteps) ? @warn("Use of the `update_timesteps` keyword argument is no longer supported or needed, time labels will be adjusted automatically if necessary.") : nothing
     parameters = Dict(Symbol(k) => v for (k, v) in parameters)
     for (param_name, value) in parameters
-        _update_param!(obj, param_name, value; update_timesteps = nothing)
+        _update_param!(obj, param_name, value)
     end
     nothing
 end

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -572,17 +572,17 @@ function _update_array_param!(obj::AbstractCompositeComponentDef, name, value)
 end
 
 """
-    update_params!(obj::AbstractCompositeComponentDef, parameters::Dict{T, Any}) where T
+    update_params!(obj::AbstractCompositeComponentDef, parameters::Dict{T, Any}; update_timesteps = nothing) where T
 
 For each (k, v) in the provided `parameters` dictionary, `update_param!`
 is called to update the external parameter by name k to value v. Each key k must be a symbol or convert to a
 symbol matching the name of an external parameter that already exists in the
 component definition.
 """
-function update_params!(obj::AbstractCompositeComponentDef, parameters::Dict)
+function update_params!(obj::AbstractCompositeComponentDef, parameters::Dict; update_timesteps = nothing)
     parameters = Dict(Symbol(k) => v for (k, v) in parameters)
     for (param_name, value) in parameters
-        _update_param!(obj, param_name, value)
+        _update_param!(obj, param_name, value; update_timesteps = nothing)
     end
     nothing
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -120,7 +120,7 @@ must be a symbol or convert to a symbol matching the name of an external paramet
 hat already exists in the model definition. The update_timesteps keyword argument 
 is deprecated, but temporarily remains as a dummy argument to allow warning detection.
 """
-@delegate update_params!(m::Model, parameters::Dict) => md
+@delegate update_params!(m::Model, parameters::Dict; update_timesteps = nothing) => md
 
 """
     add_comp!(


### PR DESCRIPTION
- We need to add the (deprecated) keyword argument `update_timesteps` to `update_params!` so that it throws a warning instead of an error 
- `update_param!` on a model definition needs to use `copyto!`, otherwise we are breaking the connection between the model instance's component instance parameters (they use views for their TimestepArray data) and the model instance's model def's external parameters

https://forum.mimiframework.org/t/using-mimiiwg-jl/158
