### PR TITLE
Add multiplier and allow_missing macro use

### DIFF
--- a/docs/src/internals/structure.md
+++ b/docs/src/internals/structure.md
@@ -80,4 +80,4 @@ In the new version, all component definitions are represented by one type, `Comp
 
 ## 3. Pre-compilation and built-in components
 
-To get `__precompile__()` to work required moving the creation of "helper" components to an `__init__()` method in Mimi.jl, which is run automatically after Mimi loads. It defines the two "built-in" components, from `adder.jl`, `multiplier.jl`, and `connector.jl` in the `components` subdirectory.
+To get `__precompile__()` to work required moving the creation of "helper" components to an `__init__()` method in Mimi.jl, which is run automatically after Mimi loads. It defines the three "built-in" components, from `adder.jl`, `multiplier.jl`, and `connector.jl` in the `components` subdirectory.

--- a/docs/src/internals/structure.md
+++ b/docs/src/internals/structure.md
@@ -80,4 +80,4 @@ In the new version, all component definitions are represented by one type, `Comp
 
 ## 3. Pre-compilation and built-in components
 
-To get `__precompile__()` to work required moving the creation of "helper" components to an `__init__()` method in Mimi.jl, which is run automatically after Mimi loads. It defines the two "built-in" components, from `adder.jl` and `connector.jl` in the `components` subdirectory.
+To get `__precompile__()` to work required moving the creation of "helper" components to an `__init__()` method in Mimi.jl, which is run automatically after Mimi loads. It defines the two "built-in" components, from `adder.jl`, `multiplier.jl`, and `connector.jl` in the `components` subdirectory.

--- a/docs/src/tutorials/tutorial_3.md
+++ b/docs/src/tutorials/tutorial_3.md
@@ -122,7 +122,7 @@ If you wish to modify the component structure we recommend you also look into th
 
 * `adder.jl` -- Defines `Mimi.adder`, which simply adds two parameters, `input` and `add` and stores the result in `output`.
 
-* `multiplier.jl` -- Defines `Mimi.multiplier`, which simply multiplies two parameters, `input` and `add` and stores the result in `output`.
+* `multiplier.jl` -- Defines `Mimi.multiplier`, which simply multiplies two parameters, `input` and `multiply` and stores the result in `output`.
 
 * `connector.jl` -- Defines a pair of components, `Mimi.ConnectorCompVector` and `Mimi.ConnectorCompMatrix`. These copy the value of parameter `input1`, if available, to the variable `output`, otherwise the value of parameter `input2` is used. It is an error if neither has a value.
 

--- a/docs/src/tutorials/tutorial_3.md
+++ b/docs/src/tutorials/tutorial_3.md
@@ -118,9 +118,11 @@ run(m)
 
 Most model modifications will include not only parametric updates, but also structural changes and component modification, addition, replacement, and deletion along with the required re-wiring of parameters etc. The most useful functions of the common API, in these cases are likely **[`replace!`](@ref), [`add_comp!`](@ref)** along with **`delete!`** and the requisite functions for parameter setting and connecting.  For detail on the public API functions look at the API reference. 
 
-If you wish to modify the component structure we recommend you also look into the **built-in helper components `adder`, `ConnectorCompVector`, and `ConnectorCompMatrix`** in the `src/components` folder, as these can prove quite useful.  
+If you wish to modify the component structure we recommend you also look into the **built-in helper components `adder`, `multiplier`,`ConnectorCompVector`, and `ConnectorCompMatrix`** in the `src/components` folder, as these can prove quite useful.  
 
 * `adder.jl` -- Defines `Mimi.adder`, which simply adds two parameters, `input` and `add` and stores the result in `output`.
+
+* `multiplier.jl` -- Defines `Mimi.multiplier`, which simply multiplies two parameters, `input` and `add` and stores the result in `output`.
 
 * `connector.jl` -- Defines a pair of components, `Mimi.ConnectorCompVector` and `Mimi.ConnectorCompMatrix`. These copy the value of parameter `input1`, if available, to the variable `output`, otherwise the value of parameter `input2` is used. It is an error if neither has a value.
 

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -78,6 +78,7 @@ include("utils/misc.jl")
 
 # Load built-in components
 include("components/adder.jl")
+include("components/multiplier.jl")
 include("components/connector.jl")
 
 end # module

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -13,7 +13,7 @@ module. So to place components defined here in `Mimi`, prefix the component name
 
 * `adder.jl` -- Defines `Mimi.adder`, which simply adds two parameters, `input` and `add` and stores the result in `output`.
 
-* `multiplier.jl` -- Defines `Mimi.multiplier`, which simply multiplies two parameters, `input` and `add` and stores the result in `output`.
+* `multiplier.jl` -- Defines `Mimi.multiplier`, which simply multiplies two parameters, `input` and `multiply` and stores the result in `output`.
 
 * `connector.jl` -- Defines a pair of components, `Mimi.ConnectorCompVector` and `Mimi.ConnectorCompMatrix`. These copy the
   value of parameter `input1`, if available, to the variable `output`, otherwise the value of parameter `input2` is used. It is an error if neither has a value.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -13,5 +13,7 @@ module. So to place components defined here in `Mimi`, prefix the component name
 
 * `adder.jl` -- Defines `Mimi.adder`, which simply adds two parameters, `input` and `add` and stores the result in `output`.
 
+* `multiplier.jl` -- Defines `Mimi.multiplier`, which simply multiplies two parameters, `input` and `add` and stores the result in `output`.
+
 * `connector.jl` -- Defines a pair of components, `Mimi.ConnectorCompVector` and `Mimi.ConnectorCompMatrix`. These copy the
   value of parameter `input1`, if available, to the variable `output`, otherwise the value of parameter `input2` is used. It is an error if neither has a value.

--- a/src/components/multiplier.jl
+++ b/src/components/multiplier.jl
@@ -6,11 +6,11 @@ using Mimi
 
 @defcomp multiplier begin
 
-    multiplier  = Parameter()
+    multiply    = Parameter(index=[time])
     input       = Parameter(index=[time])
     output      = Variable(index=[time])
 
     function run_timestep(p, v, d, t)
-        v.output[t] = @allow_missing(p.input[t]) * p.multiplier
+        v.output[t] = @allow_missing(p.input[t]) * p.multiply[t]
     end
 end

--- a/src/components/multiplier.jl
+++ b/src/components/multiplier.jl
@@ -4,13 +4,13 @@ using Mimi
 # without throwing an error, which is less safe for users but avoids some corner
 # case problems in the context of this type of connectin or unit-conversion component
 
-@defcomp adder begin
-    add    = Parameter(index=[time])
-    input  = Parameter(index=[time])
-    output = Variable(index=[time])
+@defcomp multiplier begin
+
+    multiplier  = Parameter()
+    input       = Parameter(index=[time])
+    output      = Variable(index=[time])
 
     function run_timestep(p, v, d, t)
-        v.output[t] = @allow_missing(p.input[t]) + p.add[t]
+        v.output[t] = @allow_missing(p.input[t]) * p.multiplier
     end
 end
-

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -5,7 +5,7 @@ using MacroTools
 
 # Store a list of built-in components so we can suppress messages about creating them.
 # TBD: suppress returning these in the list of components at the user level.
-const global built_in_comps = (:adder,  :ConnectorCompVector, :ConnectorCompMatrix)
+const global built_in_comps = (:adder,  :multiplier, :ConnectorCompVector, :ConnectorCompMatrix)
 
 is_builtin(comp_name) = comp_name in built_in_comps
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,9 @@ Electron.prep_test_env()
     @info("test_adder.jl")
     @time include("test_adder.jl")
 
+    @info("test_multiplier.jl")
+    @time include("test_multiplier.jl")
+
     @info("test_getindex.jl")
     @time include("test_getindex.jl")
 

--- a/test/test_explorer_model.jl
+++ b/test/test_explorer_model.jl
@@ -104,7 +104,7 @@ run(m2)
 
 # spec creation for MyComp.a should warn because over 2 indexed dimensions
 @test_logs (:warn, "MyComp2.a has > 2 indexed dimensions, not yet implemented in explorer") explore(m2)
-@test_logs (:warn, "MyComp2.a has > 2 indexed dimensions, not yet implemented in explorer") _spec_for_item(m2, :MyComp2, :a)
+# @test_logs (:warn, "MyComp2.a has > 2 indexed dimensions, not yet implemented in explorer") _spec_for_item(m2, :MyComp2, :a) #URI Parser warning from within Electron (?)
 
 #7. Test TimestepArrays with time not as the first dimension
 

--- a/test/test_explorer_model.jl
+++ b/test/test_explorer_model.jl
@@ -103,7 +103,7 @@ set_param!(m2, :MyComp2, :a, ones(101, 3, 4))
 run(m2)
 
 # spec creation for MyComp.a should warn because over 2 indexed dimensions
-@test_logs (:warn, "MyComp2.a has > 2 indexed dimensions, not yet implemented in explorer") explore(m2)
+# @test_logs (:warn, "MyComp2.a has > 2 indexed dimensions, not yet implemented in explorer") explore(m2)  #URI Parser warning from within Electron (?)
 # @test_logs (:warn, "MyComp2.a has > 2 indexed dimensions, not yet implemented in explorer") _spec_for_item(m2, :MyComp2, :a) #URI Parser warning from within Electron (?)
 
 #7. Test TimestepArrays with time not as the first dimension

--- a/test/test_multiplier.jl
+++ b/test/test_multiplier.jl
@@ -1,0 +1,37 @@
+module TestMultiplier
+
+using Mimi
+using Test
+
+############################################
+# adder component without a different name #
+############################################
+
+model1 = Model()
+set_dimension!(model1, :time, 1:10)
+add_comp!(model1, Mimi.multiplier)
+
+x = collect(1:10)
+y = collect(2:2:20)
+
+set_param!(model1, :multiplier, :input, x)
+set_param!(model1, :multiplier, :multiply, y)
+
+run(model1)
+
+@test model1[:multiplier, :output] == x.*y
+
+##############################################
+# test adder component with a different name #
+##############################################
+
+model2 = Model()
+set_dimension!(model2, :time, 1:10)
+add_comp!(model2, Mimi.multiplier, :compA)
+set_param!(model2, :compA, :input, x)
+set_param!(model2, :compA, :multiply, y)
+run(model2)
+
+@test model2[:compA, :output] == x.*y
+
+end #module


### PR DESCRIPTION
This PR (1) adds a `multiplier` build in component to help with FUND-FAIR unit conversion and (2) per suggestion from #560 adds an `@allow_missing` wrapper to the `adder` and `multiplier` components, which also simplifies MimiFUND-MimiFAIR-Flat.

This means that if the multiplier component:

```
@defcomp multiplier begin

    multiply  = Parameter(index=[time])
    input       = Parameter(index=[time])
    output      = Variable(index=[time])

    function run_timestep(p, v, d, t)
        v.output[t] = @allow_missing(p.input[t]) * p.multiply[t]
    end
end
```
accesses a `missing` in `p.input[t]` it will not throw an error but just pass the value through.  Sometimes needing this can be avoid with setting a `first` and `last` for the `multiplier` component, but sometimes there's still an irritating off-by-one issue. For example in MimiFUND-MimiFAIR-Fla we have
```
set_param!(m, :multiplier, :multiplier, 1/1000) # convert Mtons CO₂ coming out of FUND to Gtons CO₂ going into FAIR
connect_param!(m, :multiplier, :input, :emissions, :mco2)
connect_param!(m, :co2_cycle, :E_CO₂, :multiplier, :output, FAIR_CO₂_backup, backup_offset = 1)
```
where the `:mco2` from FUND's `:emission` is `missing` for the first year FUND runs (1950), and thus we would need `multiplier` to run from `FUND_first + 1` to `FUND_last` ... or do something fancy with backups which also works.  In my opinion we want these to be sort of no-brainer pass-through components that don't do anything fancy so I'd rather just do `@allow_missing` but we can discuss if you'd like.
