### PR TITLE
Check the dimensions when making internal parameter connections

### DIFF
--- a/contrib/test_all_models.jl
+++ b/contrib/test_all_models.jl
@@ -15,7 +15,7 @@ pkg_that_errored = []
 
 # first set of packages to test
 packages_to_test = [
-    "MimiDICE2010" => ("https://github.com/anthofflab/MimiDICE2010.jl", "master")
+    "MimiDICE2010" => ("https://github.com/anthofflab/MimiDICE2010.jl", "master"),
     "MimiDICE2013" => ("https://github.com/anthofflab/MimiDICE2013.jl", "master"), 
     "MimiDICE2016" => ("https://github.com/AlexandrePavlov/MimiDICE2016.jl", "master"),
     "MimiDICE2016R2" => ("https://github.com/anthofflab/MimiDICE2016R2.jl", "master"),

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -262,7 +262,7 @@ function _collect_params(md::ModelDef, var_dict::Dict{ComponentPath, Any})
         src_vars = var_dict[ipcs[1].src_comp_path]
         var_value_obj = get_property_obj(src_vars, ipcs[1].src_var_name)
         for ipc in ipcs 
-            _check_attributes(md, ipc, var_dict)
+            _check_attributes(md, ipc)
             pdict[(ipc.dst_comp_path, ipc.dst_par_name)] = var_value_obj
         end
     end

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -261,7 +261,8 @@ function _collect_params(md::ModelDef, var_dict::Dict{ComponentPath, Any})
         ipcs = _get_leaf_level_ipcs(md, conn)
         src_vars = var_dict[ipcs[1].src_comp_path]
         var_value_obj = get_property_obj(src_vars, ipcs[1].src_var_name)
-        for ipc in ipcs
+        for ipc in ipcs 
+            _check_attributes(md, ipc, var_dict)
             pdict[(ipc.dst_comp_path, ipc.dst_par_name)] = var_value_obj
         end
     end

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -134,7 +134,7 @@ function _check_attributes(obj::AbstractCompositeComponentDef, ipc::InternalPara
         end
 
         for (i, dim) in enumerate(param_dims)
-            if isa(dim, Symbol)
+            if isa(dim, Symbol) && dim !== :time # time needs a check that includes backup data (TODO)
                 param_dim_size = dim_count(obj,dim)
 
                 src_vars = var_dict[ipc.src_comp_path]

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -129,8 +129,8 @@ function _check_attributes(obj::AbstractCompositeComponentDef, ipc::InternalPara
             d1 = size(var_dims)
             d2 = size(param_dims)
             error("Mismatched dimensions of internal parameter connection: ",
-                "Component: $(nameof(Mimi.find_comp(obj, ipc.dst_comp_path))) Parameter: $(ipc.dst_par_name) (size $d2) ",
-                "Component: $(nameof(Mimi.find_comp(obj, ipc.src_comp_path))) Variable: $(ipc.src_var_name) (size $d1).")
+                "DESTINATION: Component $(nameof(Mimi.find_comp(obj, ipc.dst_comp_path)))'s Parameter $(ipc.dst_par_name) (size $d2) ",
+                "SOURCE: Component $(nameof(Mimi.find_comp(obj, ipc.src_comp_path)))'s Variable $(ipc.src_var_name) (size $d1).")
         end
 
         for (i, dim) in enumerate(param_dims)

--- a/test/test_dimensions.jl
+++ b/test/test_dimensions.jl
@@ -179,4 +179,53 @@ new_x_vals = model_params(m)[:x].values.data
 @test all(ismissing, new_x_vals[62:end])
 
 run(m)
+
+# check internal parameter connection dimensions between parameters and variable_years
+@defcomp comp1 begin
+    par1 = Parameter(index=[time])
+    var1 = Variable(index=[time])
+    function run_timestep(p,v,d,t)
+            v.var1[t] = p.par1[t]
+    end
+end
+
+@defcomp comp2 begin
+    par2 = Parameter(index=[time, country])
+    var2 = Variable(index=[time,country])
+    function run_timestep(p,v,d,t)
+            v.var2[t] = p.par2[t]
+    end
+end
+
+@defcomp comp3 begin
+    par3 = Parameter(index=[time, town])
+    var3 = Variable(index=[time,town])
+    function run_timestep(p,v,d,t)
+        v.var3[t,:] = p.par3[t,:]
+    end
+end
+
+m = Model()
+set_dimension!(m, :time, 2000:2010)
+set_dimension!(m, :country, [:A, :B, :C])
+add_comp!(m, comp1)
+add_comp!(m, comp2)
+set_param!(m, :comp1, :par1, 1:11)
+connect_param!(m, :comp2 => :par2, :comp1 => :var1)
+
+error_msg = (try eval(run(m)) catch err err end).msg
+@test occursin("Mismatched dimensions of internal parameter connection", error_msg)
+
+m = Model()
+set_dimension!(m, :time, 2000:2010)
+set_dimension!(m, :country, [:A, :B, :C])
+set_dimension!(m, :town, ["a", "b", "c", "d"])
+add_comp!(m, comp2)
+add_comp!(m, comp3)
+set_param!(m, :comp2, :par2, zeros(11,3))
+connect_param!(m, :comp3 => :par3, :comp2 => :var2)
+
+error_msg = (try eval(run(m)) catch err err end).msg
+@test occursin("Mismatched data size for internal parameter connection", error_msg)
+
 end #module

--- a/wip/dims_testing.jl
+++ b/wip/dims_testing.jl
@@ -1,0 +1,36 @@
+@defcomp comp1 begin
+   par1 = Parameter(index=[time])
+   var1 = Variable(index=[time])
+
+   function run_timestep(p,v,d,t)
+        v.var1[t] = p.par1[t]
+   end
+end
+
+@defcomp comp2 begin
+   par2 = Parameter(index=[time, country])
+   var2 = Variable(index=[time,country])
+
+   function run_timestep(p,v,d,t)
+        v.var2[t] = p.par2[t]
+   end
+end
+
+@defcomp comp3 begin
+    par3 = Parameter(index=[time, town])
+    var3 = Variable(index=[time,town])
+ 
+    function run_timestep(p,v,d,t)
+         v.var3[t,:] = p.par3[t,:]
+    end
+end
+
+ m = Model()
+set_dimension!(m, :time, 2000:2010)
+set_dimension!(m, :country, [:A, :B, :C])
+set_dimension!(m, :town, ["a", "b", "c", "d"])
+add_comp!(m, comp2)
+add_comp!(m, comp3)
+set_param!(m, :comp2, :par2, zeros(11,3))
+connect_param!(m, :comp3 => :par3, :comp2 => :var2)
+


### PR DESCRIPTION
This PR checks internal parameter connections for dimension mismatches between source variables and destination parameters.  Specifically we check that the length of each dimension in the parameter matches the length of the variable dimension in the corresponding position of the dimension list. In the future we can add checking of datatypes but for this PR we will isolate to dimensions and size issues.

TODO:

- [x] check datatypes or add this to an existing issue/add a new issue
- [x] decide how we want to handle checking the `:time` dimension - we will check although we can assume they will match given other time dim checking along the way in Mimi
- [x] move tests from the wip testing file to main tests
- [x] run `test_all_models.jl`