### PR TITLE
Unique Backup Parameter Names

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -724,8 +724,8 @@ end
 Add an model parameter with name `name` and Model Parameter `value` to ModelDef `md`.
 """
 function add_model_param!(md::ModelDef, name::Symbol, value::ModelParameter)
-    # if haskey(obj.model_params, name)
-    #     @warn "Redefining model param :$name in $(obj.comp_path) from $(obj.model_params[name]) to $value"
+    # if haskey(md.model_params, name)
+    #     @warn "Redefining model param :$name in $(md.comp_path) from $(md.model_params[name]) to $value"
     # end
     md.model_params[name] = value
     dirty!(md)
@@ -750,6 +750,9 @@ using it and only do so under the hood.
 function add_model_param!(md::ModelDef, name::Symbol, value::Number;
                             param_dims::Union{Nothing,Array{Symbol}} = nothing, 
                             is_shared::Bool = false)
+    # if haskey(md.model_params, name)
+    #     @warn "Redefining model param :$name in $(md.comp_path) from $(md.model_params[name]) to $value"
+    # end                        
     add_model_scalar_param!(md, name, value, is_shared = is_shared)
 end
 
@@ -767,6 +770,9 @@ function add_model_param!(md::ModelDef, name::Symbol,
                              value::Union{AbstractArray, AbstractRange, Tuple};
                              param_dims::Union{Nothing,Array{Symbol}} = nothing, 
                              is_shared::Bool = false)
+    # if haskey(md.model_params, name)
+    #     @warn "Redefining model param :$name in $(md.comp_path) from $(md.model_params[name]) to $value"
+    # end  
 
     ti = get_time_index_position(param_dims)
     if !isnothing(ti)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -324,10 +324,20 @@ function _connect_param!(obj::AbstractCompositeComponentDef,
 
         end
 
+        # create a backup parameter name with the destination leaf component and 
+        # parameter names, as well as a trailing integer to ensure uniqueness in
+        # edge cases.  Check if the name is already used, and if so increment the 
+        # trailing integer until it is a unique model parameter name to the model
+        i = 1
+        backup_param_name = Symbol("backup_", dst_comp_path.names[end], "_", dst_par_name, "_", i)
+        while haskey(obj.model_params, backup_param_name)
+            i += 1
+            backup_param_name = Symbol("backup_", dst_comp_path.names[end], "_", dst_par_name, "_", i)
+        end
+
         # NB: potentially unsafe way to add parameter/might be duplicating work so
         # advise shifting to create_model_param ... but leaving it as is for now
-        add_model_array_param!(obj, dst_par_name, values, dst_dims)
-        backup_param_name = dst_par_name
+        add_model_array_param!(obj, backup_param_name, values, dst_dims)
 
     else
         # cannot use backup_offset keyword argument if there is no backup


### PR DESCRIPTION
This PR handles issue #865 

When a connector component is added using backup data, the parameter name for the backup data is a model parameter (unshared) that was getting overwritten if the destination component had the same destination parameter name as another.  This PR makes sure the added model parameter has a unique name.

Should we consider a check in `add_model_param!` to make sure a given parameter does not yet exist in the model, or is overwriting sometimes desired?