### PR TITLE
Remove some type parameters

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -569,7 +569,7 @@ Note that this function `set_leftover_params! has been deprecated, and uses shou
 be transitioned to using `update_leftover_params!` with keys specific to component-parameter 
 pairs i.e. (comp_name, param_name) => value in the dictionary.
 """
-function set_leftover_params!(md::ModelDef, parameters::Dict) where T
+function set_leftover_params!(md::ModelDef, parameters::Dict)
     # @warn "The function `set_leftover_params! has been deprecated, please use `update_leftover_params!` with keys specific to component, parameter pairs i.e. (comp_name, param_name) => value in the dictionary.")
     parameters = Dict(Symbol.(k) => v for (k, v) in parameters)
     for param_ref in nothing_params(md)

--- a/src/core/dimensions.jl
+++ b/src/core/dimensions.jl
@@ -188,7 +188,7 @@ dim_count(def::AbstractDatumDef) = length(dim_names(def))
 Run through all necesssary safety checks for redefining `obj`'s time dimenson to 
 a new dimension with keys `keys`.
 """
-function _check_time_redefinition(obj::AbstractCompositeComponentDef, keys::Union{Int, Vector, Tuple, AbstractRange}) where T
+function _check_time_redefinition(obj::AbstractCompositeComponentDef, keys::Union{Int, Vector, Tuple, AbstractRange})
 
     # get useful variables 
     curr_keys = time_labels(obj)

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -160,7 +160,7 @@ end
 Save the stored simulation results in `trial_df` from trial `trialnum` to files 
 in the directory `output_dir`
 """
-function _save_trial_results(trial_df::DataFrame, datum_name::String, output_dir::AbstractString, streams::Dict{String, CSVFiles.CSVFileSaveStream{IOStream}}) where T <: AbstractSimulationData
+function _save_trial_results(trial_df::DataFrame, datum_name::String, output_dir::AbstractString, streams::Dict{String, CSVFiles.CSVFileSaveStream{IOStream}})
     filename = joinpath(output_dir, "$datum_name.csv")
     if haskey(streams, filename)
         write(streams[filename], trial_df)
@@ -365,7 +365,7 @@ end
 
 # rvalue is a Number so we might need to deal with broadcasting
 function _perturb_param!(param::ArrayModelParameter{T}, md::ModelDef, i::Int,
-                         trans::TransformSpec_ModelParams, rvalue::Number) where {T, N}
+                         trans::TransformSpec_ModelParams, rvalue::Number) where T
     op = trans.op
     pvalue = value(param)
     indices = _param_indices(param, md, i, trans)


### PR DESCRIPTION
This should fix some of the warnings on Julia 1.10