### PR TITLE
Fix small bug in Base.run for models and instances

### DIFF
--- a/src/core/instances.jl
+++ b/src/core/instances.jl
@@ -336,7 +336,7 @@ end
 Run the `ModelInstance` `mi` once with `ntimesteps` and dimension keys `dimkeys`.
 """
 function Base.run(mi::ModelInstance, ntimesteps::Int=typemax(Int),
-                  dimkeys::Union{Nothing, Dict{Symbol, Vector{T} where T <: DimensionKeyTypes}}=nothing)
+                  dimkeys::Union{Nothing, Dict{Symbol, Vector{T}} where T <: DimensionKeyTypes}=nothing)
 
     if length(components(mi)) == 0
         error("Cannot run the model: no components have been created.")

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -525,7 +525,7 @@ the specified name.
 Run model `m` once.
 """
 function Base.run(m::Model; ntimesteps::Int=typemax(Int), rebuild::Bool=false,
-                  dim_keys::Union{Nothing, Dict{Symbol, Vector{T} where T <: DimensionKeyTypes}}=nothing)
+                  dim_keys::Union{Nothing, Dict{Symbol, Vector{T}} where T <: DimensionKeyTypes}=nothing)
     if length(m) == 0
         error("Cannot run a model with no components.")
     end


### PR DESCRIPTION
The `Base.run` function allows for an optional keyword argument `dim_keys`, which (as far as I can tell) allows the user to specify a subset of time periods which the model should be run for.

This keyword argument has the following type-declaration:
`Union{Nothing, Dict{Symbol, Vector{T} where T <: DimensionKeyTypes}}`

However, this type declaration doesn't recognize a supplied value of type `Dict{Symbol, Vector{Int64}}` as valid since 
`Dict{Symbol, Vector{Int64}} <: Dict{Symbol, Vector{T} where T <: DimensionKeyTypes}` returns a value of `false`, although this is presumably the intended use of the argument.

This PR fixes this by changing the type-declaration to:
`Union{Nothing, Dict{Symbol, Vector{T}} where T <: DimensionKeyTypes}`, which ensures that arguments of the type `Dict{Symbol, Vector{Int64}}` are recognized as being valid.

This change is made in both the `src/core/model.jl` and `src/core/model.jl` files