### PR TITLE
Update julia versions for dependency model tests

### DIFF
--- a/.github/workflows/dependencytest-workflow.yml
+++ b/.github/workflows/dependencytest-workflow.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.6, 1.7]
+        julia-version: [1.9, 1.10]
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:


### PR DESCRIPTION
Model testing is successful locally, but the current code tests the models on Julia 1.6 and 1.7 seem to have some test harness issues. At this point it seems reasonable to move this model testing to Julia 1.9 and 1.10, and noting we should add more models to this list to make the testing a bit more robust.