### PR TITLE
WIP Add Dimension Key Access to `run_timestep` function

### DIFF
--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -25,7 +25,8 @@ function _generate_run_func(comp_name, module_name, args, body)
         global function $(func_name)($(p), #::Mimi.ComponentInstanceParameters,
                                      $(v), #::Mimi.ComponentInstanceVariables
                                      $(d), #::NamedTuple
-                                     $(t)) #::T <: Mimi.AbstractTimestep
+                                     $(t); #::T <: Mimi.AbstractTimestep
+                                     dim_keys::Function) #::Function
             $(body...)
             return nothing
         end
@@ -47,7 +48,8 @@ function _generate_init_func(comp_name, module_name, args, body)
     func = :(
         global function $(func_name)($(p), #::Mimi.ComponentInstanceParameters
                                      $(v), #::Mimi.ComponentInstanceVariables
-                                     $(d)) #::NamedTuple
+                                     $(d); #::NamedTuple
+                                     dim_keys::Function) #::Function
             $(body...)
             return nothing
         end

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -48,8 +48,7 @@ function _generate_init_func(comp_name, module_name, args, body)
     func = :(
         global function $(func_name)($(p), #::Mimi.ComponentInstanceParameters
                                      $(v), #::Mimi.ComponentInstanceVariables
-                                     $(d); #::NamedTuple
-                                     get_dim_keys::Function) #::Function
+                                     $(d)) #::NamedTuple
             $(body...)
             return nothing
         end

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -26,7 +26,7 @@ function _generate_run_func(comp_name, module_name, args, body)
                                      $(v), #::Mimi.ComponentInstanceVariables
                                      $(d), #::NamedTuple
                                      $(t); #::T <: Mimi.AbstractTimestep
-                                     dim_keys::Function) #::Function
+                                     get_dim_keys::Function) #::Function
             $(body...)
             return nothing
         end
@@ -49,7 +49,7 @@ function _generate_init_func(comp_name, module_name, args, body)
         global function $(func_name)($(p), #::Mimi.ComponentInstanceParameters
                                      $(v), #::Mimi.ComponentInstanceVariables
                                      $(d); #::NamedTuple
-                                     dim_keys::Function) #::Function
+                                     get_dim_keys::Function) #::Function
             $(body...)
             return nothing
         end

--- a/src/core/instances.jl
+++ b/src/core/instances.jl
@@ -312,18 +312,18 @@ function get_shifted_ts(ci, ts::VariableTimestep{TIMES}) where {TIMES}
     end
 end
 
-function run_timestep(ci::AbstractComponentInstance, clock::Clock, dims::NamedTuple, dim_keys::Function)
+function run_timestep(ci::AbstractComponentInstance, clock::Clock, dims::NamedTuple, get_dim_keys::Function)
     if ci.run_timestep !== nothing && _runnable(ci, clock)
-        ci.run_timestep(parameters(ci), variables(ci), dims, get_shifted_ts(ci, clock.ts); dim_keys=dim_keys)
+        ci.run_timestep(parameters(ci), variables(ci), dims, get_shifted_ts(ci, clock.ts); get_dim_keys=get_dim_keys)
     end
 
     return nothing
 end
 
-function run_timestep(cci::AbstractCompositeComponentInstance, clock::Clock, dims::NamedTuple, dim_keys::Function)
+function run_timestep(cci::AbstractCompositeComponentInstance, clock::Clock, dims::NamedTuple, get_dim_keys::Function)
     if _runnable(cci, clock)
         for ci in components(cci)
-            run_timestep(ci, clock, dims, dim_keys)
+            run_timestep(ci, clock, dims, get_dim_keys)
         end
     end
     return nothing
@@ -363,7 +363,7 @@ function Base.run(mi::ModelInstance, ntimesteps::Int=typemax(Int),
     # of a given dimension. This is passed through and serves as a keyword argument
     # to the run_timestep function of each component so they may access the dimension
     # key information.
-    function dim_keys(dim_name::Symbol)
+    function get_dim_keys(dim_name::Symbol)
         return dim_keys(mi, dim_name)
     end
 
@@ -371,7 +371,7 @@ function Base.run(mi::ModelInstance, ntimesteps::Int=typemax(Int),
     init(mi, dim_val_named_tuple)
 
     while ! finished(clock)
-        run_timestep(mi, clock, dim_val_named_tuple, dim_keys)
+        run_timestep(mi, clock, dim_val_named_tuple, get_dim_keys)
         advance(clock)
     end
 

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -1,4 +1,4 @@
-# @testitem "Components" begin
+@testitem "Components" begin
     import Mimi:
         compdefs, compdef, compkeys, has_comp, first_period,
         last_period, compmodule, compname, compinstance, dim_keys, dim_values,
@@ -191,4 +191,4 @@
     @test my_model[:testcomp5, :var2] == [1,2,3]
     @test my_model[:testcomp5, :var3] == [:A, :B, :C]
 
-# end
+end

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -1,4 +1,4 @@
-@testitem "Components" begin
+# @testitem "Components" begin
     import Mimi:
         compdefs, compdef, compkeys, has_comp, first_period,
         last_period, compmodule, compname, compinstance, dim_keys, dim_values,
@@ -160,4 +160,35 @@
     ci = compinstance(m, :C) # Get the component instance
     @test ci.first == 2010      # The component instance's first and last values are the same as the comp def
     @test ci.last == 2090
-end
+
+    # 3. Test using the dim_keys function in run_timestep
+    my_model = Model()
+    set_dimension!(my_model, :time, 2000:2010) # Set the time dimension
+    set_dimension!(my_model, :region, [:A, :B, :C]) # Set the region dimension
+
+    @defcomp testcomp5 begin
+
+        var1 = Variable(index=[time])
+        par1 = Parameter(index=[time])
+
+        var2 = Variable{Int}(index=[region]) # hold region idxs 1:n
+        var3 = Variable{Symbol}(index=[region]) # hold region keys
+
+        function run_timestep(p, v, d, t)
+            v.var1[t] = p.par1[t]
+            for region in d.region
+                v.var2[region] = region
+                v.var3[region] = dim_keys(:region)[region]
+            end
+        end
+    end
+
+    add_comp!(my_model, testcomp5)
+    update_param!(my_model, :testcomp5, :par1, collect(1:11))
+
+    run(my_model)
+
+    @test my_model[:testcomp5, :var2] == [1,2,3]
+    @test my_model[:testcomp5, :var3] == [:A, :B, :C]
+
+# end

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -178,7 +178,7 @@
             v.var1[t] = p.par1[t]
             for region in d.region
                 v.var2[region] = region
-                v.var3[region] = dim_keys(:region)[region]
+                v.var3[region] = get_dim_keys(:region)[region]
             end
         end
     end


### PR DESCRIPTION
Handling part of #948 (also mentions access to `t` in `init` but save that for a second PR)

The goal of this PR is to add access to the dimension **keys** from within components. Currently for a `run_timestep(p,v,d,t)` function, `d.dim_name` will return a vector of the `Type` needed to **index** into Arrays for the dimension, namely `Int`s for all dimensions except `time` for which it is our custom `Timestep` type.

While this is useful for a loop like
```Julia
for d in d.countries
    v.var1[d] = p.par1 * p.mulitplier[d]
end
```
there are times a user would like to check the actual keys, I think the core example being something like 
```Julia
for d in d.countries
    if d == "USA" # FAILS
        # do something
    else
        # do something else
    end
end
```
Note the line above fails because `d` is an Integer (eg. in GIVE we know it is 174, the index of the key "USA" in the countries dimension vector).

One way to pass information to `run_timestep` without breaking compatibility is to have keyword args we set during initialization, and then are in scope for the function, that the user never needs to see or manipulate. We have access to the entire `ModelInstance` at the time of running `run_timestep`.

Some decisions/TODOs

1. What should we pass? On my first try I pass a `get_dim_keys(dim_name::Symbol)` function, but we could really pass any structure that is useful. Instead of a function we could have an object called `d_keys` that is exactly the same as `d` but returns the keys?
2. Add this to `init` as well (?)
3. Think carefully about the time dimension keys here -- there can be offsets etc.
4. Add tests