### PR TITLE
Pass simulation data via CSV file to explorer

### DIFF
--- a/src/explorer/assets/main.html
+++ b/src/explorer/assets/main.html
@@ -3,13 +3,11 @@
 <html>
 <header>
     
-    <script src="https://cdn.jsdelivr.net/npm/vega@3"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vega-lite@2"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vega-embed@3"></script> 
-
-    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.8/vega.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.3/vega-lite.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-rc7/vega-embed.js"></script> -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-loader-arrow"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+    
     
     <link rel="stylesheet" type="text/css" href="style.css" />
 

--- a/src/explorer/assets/refresh.js
+++ b/src/explorer/assets/refresh.js
@@ -1,3 +1,5 @@
+const fs = require('node:fs/promises');
+
 // Mimi UI
 
 function refresh(menu_item_list) {
@@ -30,5 +32,15 @@ function refresh(menu_item_list) {
 }
 
 function display(spec) {
-    vegaEmbed("#vis", spec["VLspec"], {actions: false});
+    const loader = {
+        load: async function(uri, options) {
+            const parsedUri = new URL(uri)
+            if (parsedUri.protocol!='file') {
+                throw new Error('Only file URIs are allowed in the vega-lite spec.');
+            }
+
+            return await fs.readFile(new URL(uri))
+        },
+    }
+    vegaEmbed("#vis", spec["VLspec"], {actions: false, loader: loader});
 }

--- a/src/explorer/buildspecs.jl
+++ b/src/explorer/buildspecs.jl
@@ -493,14 +493,17 @@ function createspec_trumpet_static(name, df, dffields)
 end
 
 function createspec_trumpet_interactive(name, df, dffields)
+    temp_data_file_name = tempname()
 
-    datapart = getdatapart(df, dffields, :trumpet) #returns JSONtext type 
+    df = select(df, 1 => (i -> Date.(i)) => :time, 2, 3, copycols=false)
+    CSVFiles.save(CSVFiles.FileIO.File{CSVFiles.FileIO.format"CSV"}(temp_data_file_name), df)
+    
     spec = Dict(
         "name"  => name,
         "VLspec" => Dict(
-            "\$schema" => "https://vega.github.io/schema/vega-lite/v3.json",
+            "\$schema" => "https://vega.github.io/schema/vega-lite/v5.json",
             "description" => "plot for a specific component variable pair",
-            "data"=> Dict("values" => datapart),
+            "data"=> Dict("url" => string(URI(FilePaths.Path(temp_data_file_name))), "format" => Dict("type" => "csv")),
             "vconcat" => [
                 Dict(
                     "title" => "$name",


### PR DESCRIPTION
This might work better with large simulation data than the current approach. I only implemented it for one specific plot type. If this works we might also use this approach for other figures.

Also updated vega and vega-lite to their latest versions.