### PR TITLE
Bump minimal Julia version to 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,7 +54,7 @@ StatsBase = "0.32, 0.33, 0.34"
 StringBuilders = "0.2, 0.3"
 TableTraits = "0.4.1, 1"
 VegaLite = "1, 2, 3"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
Given that 1.10 is the new LTS.